### PR TITLE
Fix CI config so it runs on all branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,6 @@
 name: Rust
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Previously it only ran for `master` (or PRs targeting `master`), but the default branch is now `main`.

I've switched this to run for all branches (rather than just `main`), since it's useful to be able to see whether tests pass without having to open a PR.

See:
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on

Fixes GUS-W-9679128.