### PR TITLE
CI: Remove --all-targets from `cargo {build,test}`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       # Not using --locked since Cargo.lock is in .gitignore.
-      run: cargo build --all-targets --all-features
+      run: cargo build --all-features
     - name: Run tests
-      run: cargo test --all-targets --all-features
+      run: cargo test --all-features


### PR DESCRIPTION
Since unlike `cargo clippy` (where it's required to ensure everything is linted), for `cargo build` it's somewhat unnecessary (as we don't have any of the additional targets such as examples or benches (the examples we have aren't detected/built currently and should probably be their own step anyway), and in the case of `cargo test`, actually means less is tested (the doc-tests are omitted?!).

See:
https://doc.rust-lang.org/cargo/commands/cargo-build.html#target-selection
https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection

GUS-W-9821318.