### PR TITLE
Assert literal toml string

### DIFF
--- a/src/data/launch.rs
+++ b/src/data/launch.rs
@@ -27,7 +27,15 @@ pub struct Launch {
 /// false).unwrap();
 ///
 /// launch_toml.processes.push(web);
-/// assert!(toml::to_string(&launch_toml).is_ok());
+/// let toml_string = toml::to_string(&launch_toml);
+/// assert!(toml_string.is_ok());
+/// assert_eq!(toml_string.unwrap(), r#"
+/// [[processes]]
+/// type = "web"
+/// command = "bundle"
+/// args = ["exec", "ruby", "app.rb"]
+/// direct = false
+/// "#.trim_start());
 /// ```
 impl Launch {
     pub fn new() -> Self {


### PR DESCRIPTION
This isn't ideal as it's sensitive to changes in the output that won't affect the parsing. For instance if it decided to put two spaces on each side of the equals it would be the same toml output.

Ideally I would like to re-serialize it into TOML and assert specific values of it similar to https://github.com/heroku/buildpacks-ruby/blob/7893817cf76b36718da82ab294f2c5c3b7da9fab/spec/unit/bash_functions_spec.rb#L193-L196. I played around with the toml library interface but couldn't figure out how to get something like that working.