### PR TITLE
Add runtime error message on CNB API version mismatch

### DIFF
--- a/src/data/buildpack.rs
+++ b/src/data/buildpack.rs
@@ -3,6 +3,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use semver::Version;
 use serde::{de, Deserialize};
+use std::fmt::{Display, Formatter};
 use std::{fmt, str::FromStr};
 use thiserror;
 
@@ -76,7 +77,7 @@ pub struct Group {
     pub optional: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct BuildpackApi {
     pub major: u32,
     pub minor: u32,
@@ -112,6 +113,12 @@ impl FromStr for BuildpackApi {
         }
 
         Err(BuildpackTomlError::InvalidBuildpackApi(String::from(value)))
+    }
+}
+
+impl Display for BuildpackApi {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&format!("{}.{}", self.major, self.minor))
     }
 }
 
@@ -351,5 +358,12 @@ id = "io.buildpacks.stacks.bionic"
         if let Ok(toml) = result {
             assert!(!toml.order.get(0).unwrap().group.get(0).unwrap().optional);
         }
+    }
+
+    #[test]
+    fn buildpack_api_display() {
+        assert_eq!(BuildpackApi { major: 1, minor: 0 }.to_string(), "1.0");
+        assert_eq!(BuildpackApi { major: 1, minor: 2 }.to_string(), "1.2");
+        assert_eq!(BuildpackApi { major: 0, minor: 5 }.to_string(), "0.5");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod data;
 pub mod layer_env;
 
 pub mod layer_lifecycle;
+
+use crate::data::buildpack::BuildpackApi;
 pub use build::BuildContext;
 pub use detect::DetectContext;
 pub use detect::DetectOutcome;
@@ -22,3 +24,5 @@ mod generic;
 mod platform;
 mod runtime;
 mod toml_file;
+
+const LIBCNB_SUPPORTED_BUILDPACK_API: BuildpackApi = BuildpackApi { major: 0, minor: 5 };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -70,8 +70,12 @@ pub fn cnb_runtime<P: Platform, BM: DeserializeOwned, E: Debug + Display>(
             if buildpack_toml.api != LIBCNB_SUPPORTED_BUILDPACK_API {
                 eprintln!("Error: Cloud Native Buildpack API mismatch");
                 eprintln!(
-                    "This buildpack uses Cloud Native Buildpacks API version {}, but the underlying libcnb.rs library requires CNB API {}.",
-                    &buildpack_toml.api,
+                    "This buildpack ({}) uses Cloud Native Buildpacks API version {}.",
+                    &buildpack_toml.buildpack.name, &buildpack_toml.api,
+                );
+
+                eprintln!(
+                    "But the underlying libcnb.rs library requires CNB API {}.",
                     LIBCNB_SUPPORTED_BUILDPACK_API
                 );
 


### PR DESCRIPTION
Looking at #48 and #49, we need to be more explicit about the supported CNB API versions. There is an issue about this already (#29) which looks at the problem at a higher level. This PR adds an error message if the API versions in the  `buildpack.toml` and the supported CNB API version of ´libcnb.rs` do not match.

"But what is the supported CNB API version?" you might ask. This is not really clear and currently undocumented. To determine which version we initially targeted when we started writing libcnb, I looked at the [CNB spec releases](https://github.com/buildpacks/spec/releases) and found out that the de-facto supported version is `0.5`.

The main giveaway is the implementation of [RFC 0070](https://github.com/buildpacks/rfcs/blob/main/text/0070-new-buildpack-toml-keys.md) that landed in `0.6` which is currently unsupported. This also matches up with timeline when we started working on this: around December 2020 (https://github.com/Malax/libcnb.rs/commit/74400926a47e9fbd38b2258f6d2e5011c505c056).

So this currently checks for CNB API version `0.5`.