### PR TITLE
Add an 'include' directive to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Rust language binding of the Cloud Native Buildpack spec."
 repository = "https://github.com/Malax/libcnb.rs"
 documentation = "https://docs.rs/libcnb"
 readme = "README.md"
+include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To prevent unwanted files from being published in the create:
https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields

Generated by cargo-diet:
https://github.com/the-lean-crate/cargo-diet

```
$ cargo diet
┌──────────────────────────┬─────────────┐
│ Removed File             │ Size (Byte) │
├──────────────────────────┼─────────────┤
│ .gitignore               │          44 │
│ .github/dependabot.yml   │         205 │
│ .github/workflows/ci.yml │         888 │
└──────────────────────────┴─────────────┘
Saved 1% or 1.1 KB in 3 files (of 106.9 KB and 28 files in entire crate)

The following change was made to Cargo.toml:
Diff - removed / added + :
[…skipped 8 lines…]
documentation = "https://docs.rs/libcnb"
readme = "README.md"
+include = ["src/**/*", "LICENSE", "README.md"]

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
[…skipped 13 lines…]
```

GUS-W-9868830.