### PR TITLE
Allow ProcessTypes to be compared

### DIFF
--- a/src/data/launch.rs
+++ b/src/data/launch.rs
@@ -99,7 +99,7 @@ pub struct Slice {
 /// let invalid = ProcessType::from_str("!nv4lid");
 /// assert!(invalid.is_err());
 /// ```
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 pub struct ProcessType(String);
 
 impl ProcessType {
@@ -131,4 +131,22 @@ pub enum ProcessTypeError {
         "Found `{0}` but value MUST only contain numbers, letters, and the characters ., _, and -."
     )]
     InvalidProcessType(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_process_type_eq() {
+        assert_eq!(
+            ProcessType::from_str("web").unwrap(),
+            ProcessType::from_str("web").unwrap()
+        );
+        assert_ne!(
+            ProcessType::from_str("web").unwrap(),
+            ProcessType::from_str("nope").unwrap()
+        )
+    }
 }


### PR DESCRIPTION
While writing a build pack I wanted to test that an `Launch::r#type` was properly set and tried to use `assert_eq!`. To my surprise I found that it could not be compared:

```
error[E0369]: binary operation `==` cannot be applied to type `ProcessType`
   --> src/data/launch.rs:146:9
    |
146 |           assert_eq!(
    |  _________^
    | |_________|
    | |
147 | |             ProcessType::from_str("web").unwrap(),
148 | |             ProcessType::from_str("web").unwrap()
149 | |         )
    | |         ^
    | |_________|
    | |_________ProcessType
    |           ProcessType
```

This is fixed by setting the partial eq trait https://doc.rust-lang.org/std/cmp/trait.PartialEq.html.