### PR TITLE
Enable rustc's unused_crate_dependencies lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! This crate provides a library to implement [Cloud Native Buildpacks](https://buildpacks.io/).
 
-// Enable Clippy lints that are disabled by default.
+// Enable rustc and Clippy lints that are disabled by default.
+// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
+#![warn(unused_crate_dependencies)]
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
 // Re-disable pedantic lints that are currently failing, until they are triaged and fixed/wontfixed.


### PR DESCRIPTION
To ensure the crate doesn't have unused dependencies:
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies

GUS-W-9888470.