### PR TITLE
example-02 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 Cargo.lock
 examples/**/target
+examples/**/target-cargo

--- a/examples/example-02-ruby-sample/Cargo.lock
+++ b/examples/example-02-ruby-sample/Cargo.lock
@@ -10,18 +10,18 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.41"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "autocfg"
@@ -136,7 +136,7 @@ dependencies = [
  "anyhow",
  "flate2",
  "libcnb",
- "openssl-sys",
+ "openssl",
  "reqwest",
  "serde",
  "sha2",
@@ -496,9 +496,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mime"
@@ -610,15 +610,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg",
  "cc",
@@ -656,15 +656,6 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
 
 [[package]]
 name = "pin-project"
@@ -803,21 +794,20 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -904,21 +894,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 dependencies = [
- "semver-parser",
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -1033,31 +1013,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -1174,12 +1145,6 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/examples/example-02-ruby-sample/Cargo.toml
+++ b/examples/example-02-ruby-sample/Cargo.toml
@@ -16,7 +16,4 @@ toml = "0.5"
 tempfile = "3"
 "libcnb" = { path = "../..", features = ["anyhow"] }
 serde = "1.0.126"
-openssl-sys = "*"
-
-[features]
-vendored-openssl = ["openssl-sys/vendored"]
+openssl = { version = "0.10.36", features = ["vendored"] }

--- a/examples/example-02-ruby-sample/Makefile.toml
+++ b/examples/example-02-ruby-sample/Makefile.toml
@@ -1,0 +1,105 @@
+[env]
+CARGO_TARGET_DIR="./target-cargo"
+
+[env.development]
+CARGO_PROFILE = "debug"
+BUILD_FLAGS = ["build", "--target", "x86_64-unknown-linux-musl"]
+
+[env.production]
+CARGO_PROFILE = "release"
+BUILD_FLAGS = ["build", "--target", "x86_64-unknown-linux-musl", "--release"]
+
+[tasks.build]
+args = ["@@split(BUILD_FLAGS, ;)"]
+
+[tasks.build.mac]
+dependencies = ["check-crosscompile-mac-deps"]
+
+[tasks.build.mac.env]
+"CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER" = "x86_64-linux-musl-ld"
+"CC_x86_64_unknown_linux_musl" = "x86_64-linux-musl-gcc"
+
+[tasks.strip]
+condition = { profiles = [ "production" ], platforms = [ "linux" ] }
+command = "strip"
+args = ["target-cargo/x86_64-unknown-linux-musl/${CARGO_PROFILE}/${CARGO_MAKE_CRATE_NAME}"]
+
+[tasks.check-crosscompile-mac-deps]
+script_runner = "@rust"
+script = '''
+//! ```cargo
+//! [dependencies]
+//! which = "4.0.2"
+//! colored = "2.0.0"
+//! ```
+// Silence warning from rust-script:
+#![allow(non_snake_case)]
+
+use which::which;
+use colored::*;
+use std::path::PathBuf;
+use std::process::exit;
+
+fn main() {
+    let required_binaries = vec!["x86_64-linux-musl-ld", "x86_64-linux-musl-gcc"];
+    let binaries = required_binaries.iter().map(which).collect::<Result<Vec<PathBuf>, _>>();
+    if binaries.is_err() {
+        println!("{}", "Required binaries for cross-compilation missing".bold().red());
+        println!("{}", "===============================================".bold().red());
+        println!("{}", "! Please make sure to install homebrew-musl-cross to enable cross compilation to Linux.".bold().red());
+        println!("{}", "! https://github.com/FiloSottile/homebrew-musl-cross".bold().red());
+        println!("");
+        println!("Exiting...");
+        exit(1);
+    }
+}
+'''
+
+[tasks.copy-files]
+script_runner = "@rust"
+script = '''
+//! ```cargo
+//! [dependencies]
+//! colored = "2.0.0"
+//! ```
+// Silence warning from rust-script:
+#![allow(non_snake_case)]
+
+use std::path::PathBuf;
+use std::fs;
+use std::collections::HashMap;
+use colored::*;
+
+fn main() {
+    let destination = PathBuf::from("target");
+    if destination.exists() {
+        fs::remove_dir_all(&destination).unwrap();
+    }
+    fs::create_dir_all(&destination.join("bin")).unwrap();
+
+    let mut files = HashMap::new();
+    files.insert(PathBuf::from("./target-cargo/x86_64-unknown-linux-musl").join(env!("CARGO_PROFILE")).join(env!("CARGO_MAKE_CRATE_NAME")), destination.join("bin/build"));
+    files.insert(PathBuf::from("./buildpack.toml"), destination.join("buildpack.toml"));
+    files.insert(PathBuf::from("./package.toml"), destination.join("package.toml"));
+
+    for (from, to) in &files {
+        fs::copy(from, to).unwrap();
+    }
+
+    fs::hard_link(destination.join("bin/build"), destination.join("bin/detect")).unwrap();
+
+    println!("{}", "Successfully created buildpack directory".bold().green());
+    println!("{}", "========================================".bold().green());
+    println!("To try out your buildpack run:");
+    println!("$ pack build rust-cnb-starter -b {} --path {}", destination.to_str().unwrap().bold(), "$APP_DIR".bold());
+    println!("");
+
+}
+'''
+
+[tasks.pack]
+dependencies = [
+    "build",
+    "strip",
+    "copy-files"
+]

--- a/examples/example-02-ruby-sample/buildpack.toml
+++ b/examples/example-02-ruby-sample/buildpack.toml
@@ -1,5 +1,5 @@
 # Buildpack API version
-api = "0.4"
+api = "0.5"
 
 # Buildpack ID and metadata
 [buildpack]

--- a/examples/example-02-ruby-sample/package.toml
+++ b/examples/example-02-ruby-sample/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+uri = "."

--- a/examples/example-02-ruby-sample/src/layers/bundler.rs
+++ b/examples/example-02-ruby-sample/src/layers/bundler.rs
@@ -24,7 +24,7 @@ pub struct BundlerLayerMetadata {
 
 impl LayerLifecycle<GenericPlatform, RubyBuildpackMetadata, BundlerLayerMetadata, Option<()>, anyhow::Error> for BundlerLayerLifecycle {
     fn validate(&self, layer_path: &Path, layer_content_metadata: &LayerContentMetadata<BundlerLayerMetadata>, build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> ValidateResult {
-        let checksum_matches = sha256_checksum(layer_path.join("Gemfile.lock"))
+        let checksum_matches = sha256_checksum(build_context.app_dir.join("Gemfile.lock"))
             .map(|local_checksum| local_checksum == layer_content_metadata.metadata.checksum)
             .unwrap_or(false);
 
@@ -81,7 +81,7 @@ impl LayerLifecycle<GenericPlatform, RubyBuildpackMetadata, BundlerLayerMetadata
         }
 
         Ok(LayerContentMetadata::default().launch(true).cache(true).metadata(BundlerLayerMetadata {
-            checksum: sha256_checksum(layer_path.join("Gemfile.lock"))?
+            checksum: sha256_checksum(build_context.app_dir.join("Gemfile.lock"))?
         }))
     }
 }


### PR DESCRIPTION
- bump buildpack API version
- move to vendored OpenSSL for easy cross-building from macOS
- add `Makefile.toml` and `package.toml` for easy builds
- fix `Gemfile.lock` checksumming (was looking in the wrong dir, always failing at runtime)

`layer_lifecycle_data` isn't working yet (none of the env vars end up in the built image), that somehow got broken in the 00e20e8ba5021923217b80d5d2fa4174d6f836b1 refactor