### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Manuel Fuchs <malax@malax.de>", "Terence Lee <hone02@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Major version bump due to the breaking changes in #50.

Changes:
https://github.com/Malax/libcnb.rs/compare/v0.2.0...2f4247f81edcafe547a7c8d39eae91e308ddc1cd

GUS-W-9915577.