### PR TITLE
Introduce test_helper::TempContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,4 @@ serde = { version = "^1.0.126", features = ["derive"] }
 thiserror = "^1.0.26"
 toml = "^0.5.8"
 anyhow = { version = "^1.0.42", optional = true }
-
-[dev-dependencies]
 tempfile = "^3.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod data;
 pub mod layer_env;
 
 pub mod layer_lifecycle;
+pub mod test_helper;
 
 use crate::data::buildpack::BuildpackApi;
 pub use build::BuildContext;

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -1,0 +1,2 @@
+pub mod temp_context;
+pub use temp_context::TempContext;

--- a/src/test_helper/temp_context.rs
+++ b/src/test_helper/temp_context.rs
@@ -1,0 +1,115 @@
+use crate::{
+    data::buildpack::BuildpackToml, data::buildpack_plan::BuildpackPlan,
+    data::buildpack_plan::Entry, BuildContext, DetectContext, GenericBuildContext,
+    GenericDetectContext, GenericMetadata, GenericPlatform, Platform,
+};
+
+/// Creates build and detect contexts with references to temp directories for testing
+///
+/// When the context goes out of scope, the directories are cleaned from disk.
+///
+///```
+/// use libcnb::test_helper::TempContext;
+/// use std::fs;
+///
+/// pub fn build(context: libcnb::GenericBuildContext) {}
+/// pub fn detect(context: libcnb::GenericDetectContext) {}
+///
+/// let temp = TempContext::new("heroku-20", include_str!("../../examples/example-02-ruby-sample/buildpack.toml"));
+/// let build_context = temp.build;
+/// let detect_context = temp.detect;
+/// let launch_toml_path = build_context.layers_dir.join("launch.toml");
+///
+/// std::fs::write(build_context.app_dir.join("Procfile"), "web: bundle exec rails s").unwrap();
+///
+/// // Pass to build to assert behavior
+/// build(build_context);
+///
+/// // Pass to detect to assert behavior
+/// detect(detect_context);
+///```
+pub struct TempContext {
+    pub detect: GenericDetectContext,
+    pub build: GenericBuildContext,
+    _tmp_dir: tempfile::TempDir,
+}
+
+impl TempContext {
+    pub fn new(stack_id: impl AsRef<str>, buildpack_toml_string: impl AsRef<str>) -> Self {
+        let buildpack_toml_string = buildpack_toml_string.as_ref();
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let app_dir = tmp_dir.path().join("app");
+        let layers_dir = tmp_dir.path().join("layers");
+        let platform_dir = tmp_dir.path().join("platform");
+        let buildpack_dir = tmp_dir.path().join("buildpack");
+
+        for dir in [&app_dir, &layers_dir, &buildpack_dir, &platform_dir] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+
+        let stack_id = String::from(stack_id.as_ref());
+        let platform = GenericPlatform::from_path(&platform_dir).unwrap();
+        let buildpack_descriptor: BuildpackToml<GenericMetadata> =
+            toml::from_str(buildpack_toml_string).unwrap();
+
+        let detect_context = DetectContext {
+            platform,
+            buildpack_descriptor,
+            app_dir: app_dir.clone(),
+            buildpack_dir: buildpack_dir.clone(),
+            stack_id: stack_id.clone(),
+        };
+
+        let platform = GenericPlatform::from_path(&platform_dir).unwrap();
+        let buildpack_descriptor: BuildpackToml<GenericMetadata> =
+            toml::from_str(buildpack_toml_string).unwrap();
+        let buildpack_plan = BuildpackPlan {
+            entries: Vec::<Entry>::new(),
+        };
+        let build_context = BuildContext {
+            layers_dir,
+            app_dir,
+            buildpack_dir,
+            stack_id,
+            platform,
+            buildpack_plan,
+            buildpack_descriptor,
+        };
+
+        TempContext {
+            detect: detect_context,
+            build: build_context,
+            _tmp_dir: tmp_dir,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_directories_are_created() {
+        let temp = TempContext::new("heroku-20", fake_buildpack_toml());
+        assert!(temp.build.app_dir.exists());
+        assert!(temp.build.layers_dir.exists());
+        assert!(temp.build.buildpack_dir.exists());
+
+        assert!(temp.detect.app_dir.exists());
+        assert!(temp.detect.buildpack_dir.exists());
+    }
+
+    fn fake_buildpack_toml() -> &'static str {
+        r#"
+            api = "0.4"
+
+            [buildpack]
+            id = "com.examples.buildpacks.ruby"
+            version = "0.0.1"
+            name = "Ruby Buildpack"
+
+            [[stacks]]
+            id = "io.buildpacks.stacks.bionic"
+        "#
+    }
+}


### PR DESCRIPTION
When exercising `build()` and `detect()` in tests we need an easy way to generate a `GenericBuildContext` and `GenericDetectContext`. This commit adds a helper that creates these structs and associated temporary directories.

GUS-W-9909197