### PR TITLE
refactor Error enums

### DIFF
--- a/libcnb/src/layer_lifecycle.rs
+++ b/libcnb/src/layer_lifecycle.rs
@@ -318,12 +318,10 @@ pub fn execute_layer_lifecycle<
     layer_lifecycle.on_lifecycle_end();
 
     match context.read_layer_content_metadata(&layer_name) {
-        Err(toml_file_error) => Err(Error::LayerLifecycleError(
-            LayerLifecycleError::CannotReadLayerContentMetadata(toml_file_error),
-        )),
-        Ok(None) => Err(Error::LayerLifecycleError(
-            LayerLifecycleError::CannotFindLayerMetadataAfterLifecycle(),
-        )),
+        Err(toml_file_error) => {
+            Err(LayerLifecycleError::CannotReadLayerContentMetadata(toml_file_error).into())
+        }
+        Ok(None) => Err(LayerLifecycleError::CannotFindLayerMetadataAfterLifecycle().into()),
         Ok(Some(metadata)) => layer_lifecycle
             .layer_lifecycle_data(&layer_path, metadata)
             .map_err(Error::BuildpackError),
@@ -401,9 +399,7 @@ fn handle_layer_recreate<
 
     context
         .write_layer_content_metadata(&layer_name, &content_metadata)
-        .map_err(|toml_error| {
-            Error::LayerLifecycleError(LayerLifecycleError::CannotWriteLayerMetadata(toml_error))
-        })
+        .map_err(|toml_error| LayerLifecycleError::CannotWriteLayerMetadata(toml_error).into())
 }
 
 fn handle_layer_update<
@@ -427,9 +423,7 @@ fn handle_layer_update<
 
     context
         .write_layer_content_metadata(&layer_name, &content_metadata)
-        .map_err(|toml_error| {
-            Error::LayerLifecycleError(LayerLifecycleError::CannotWriteLayerMetadata(toml_error))
-        })
+        .map_err(|toml_error| LayerLifecycleError::CannotWriteLayerMetadata(toml_error).into())
 }
 
 fn metadata_recovery<
@@ -449,9 +443,7 @@ fn metadata_recovery<
         let maybe_layer_content_metadata = context
             .read_layer_content_metadata(&layer_name)
             .map_err(|toml_file_error| {
-                Error::LayerLifecycleError(LayerLifecycleError::CannotNotReadUntypedLayerMetadata(
-                    toml_file_error,
-                ))
+                LayerLifecycleError::CannotNotReadUntypedLayerMetadata(toml_file_error)
             })?;
 
         match maybe_layer_content_metadata {


### PR DESCRIPTION
this commit splits the large Error enum into some smaller ones
* LibError which will happen usually due to bugs from Platform errors
* DataError this will happen when parsing bad data types from the spec

This should help #96 remove the unnecessary Error generics on `fn buildl()`, since it will never have a `BuildpackError(E)`.

```
pub fn build(self) -> Result<DetectContext<P, BM>, crate::error::LibError>
```

The biggest downside of doing this is nested enum handling.