### PR TITLE
fix clippy after statement warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,6 @@
 #![allow(clippy::doc_markdown)]
 // https://github.com/Malax/libcnb.rs/issues/65
 #![allow(clippy::implicit_clone)]
-// https://github.com/Malax/libcnb.rs/issues/56
-#![allow(clippy::items_after_statements)]
 // https://github.com/Malax/libcnb.rs/issues/59
 #![allow(clippy::map_unwrap_or)]
 // https://github.com/Malax/libcnb.rs/issues/62


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#items_after_statements
Addresses Issue #56