### PR TITLE
use map_or when map and unwrap_or is used

### DIFF
--- a/src/data/buildpack.rs
+++ b/src/data/buildpack.rs
@@ -159,8 +159,7 @@ impl FromStr for BuildpackApi {
                 // If no minor version is specified default to 0.
                 let minor = captures
                     .name("minor")
-                    .map(|s| s.as_str())
-                    .unwrap_or("0")
+                    .map_or("0", |s| s.as_str())
                     .parse::<u32>()
                     .map_err(|_| BuildpackTomlError::InvalidBuildpackApi(String::from(value)))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 #![allow(clippy::implicit_clone)]
 // https://github.com/Malax/libcnb.rs/issues/56
 #![allow(clippy::items_after_statements)]
-// https://github.com/Malax/libcnb.rs/issues/59
-#![allow(clippy::map_unwrap_or)]
 // https://github.com/Malax/libcnb.rs/issues/62
 #![allow(clippy::match_wildcard_for_single_variants)]
 // https://github.com/Malax/libcnb.rs/issues/53


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#map_unwrap_or
Addressing Issue #59 