### PR TITLE
Implement Default for LayerContentTypeTable

### DIFF
--- a/libcnb-data/src/layer_content_metadata.rs
+++ b/libcnb-data/src/layer_content_metadata.rs
@@ -19,7 +19,7 @@ pub struct LayerContentTypeTable {
     pub cache: bool,
 }
 
-impl LayerContentTypeTable {
+impl Default for LayerContentTypeTable {
     fn default() -> Self {
         Self {
             launch: false,
@@ -54,7 +54,7 @@ impl LayerContentTypeTable {
 /// ```
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LayerContentMetadata<M> {
-    #[serde(default = "LayerContentTypeTable::default")]
+    #[serde(default)]
     pub types: LayerContentTypeTable,
 
     /// Metadata that describes the layer contents.


### PR DESCRIPTION
Implement [`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) for `LayerContentTypeTable` instead of having a regular function called `default`. This allows us to use abstractions over "things that have a default value" instead of writing special code when `LayerContentTypeTable` is involved.

For example, we can now use `#[serde(default)]` instead of `#[serde(default = "LayerContentTypeTable::default")]` as seen in this PR.