### PR TITLE
Generalize StackId type

### DIFF
--- a/libcnb-data/src/lib.rs
+++ b/libcnb-data/src/lib.rs
@@ -23,4 +23,5 @@ pub mod buildpack_plan;
 pub mod defaults;
 pub mod launch;
 pub mod layer_content_metadata;
+pub mod stack_id;
 pub mod store;

--- a/libcnb-data/src/stack_id.rs
+++ b/libcnb-data/src/stack_id.rs
@@ -1,0 +1,64 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+use serde::Deserialize;
+use std::str::FromStr;
+
+/// Stack Id. This is a newtype wrapper around a String.
+/// It MUST only contain numbers, letters, and the characters ., /, and -.
+/// or be `*`.
+///
+/// Use [`std::str::FromStr`] to create a new instance of this struct.
+///
+/// # Examples
+/// ```
+/// use std::str::FromStr;
+/// use libcnb_data::stack_id::StackId;
+///
+/// let valid = StackId::from_str("io.buildpacks.bionic/Latest-2020");
+/// assert_eq!(valid.unwrap().as_str(), "io.buildpacks.bionic/Latest-2020");
+///
+/// let invalid = StackId::from_str("!nvalid");
+/// assert!(invalid.is_err());
+///
+/// let valid = StackId::from_str("*");
+/// assert!(valid.is_ok());
+/// ```
+#[derive(Deserialize, Debug)]
+pub struct StackId(String);
+
+#[derive(thiserror::Error, Debug)]
+pub enum StackIdError {
+    #[error(
+    "Found `{0}` but value MUST only contain numbers, letters, and the characters `.`, `/`, and `-`. or only `*`"
+    )]
+    InvalidStackId(String),
+}
+
+impl FromStr for StackId {
+    type Err = StackIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(r"^([[:alnum:]./-]+|\*)$").unwrap();
+        }
+
+        let string = String::from(value);
+        if RE.is_match(value) {
+            Ok(Self(string))
+        } else {
+            Err(StackIdError::InvalidStackId(string))
+        }
+    }
+}
+
+impl From<StackId> for String {
+    fn from(stack_id: StackId) -> Self {
+        stack_id.0
+    }
+}
+
+impl StackId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}

--- a/libcnb-data/src/stack_id.rs
+++ b/libcnb-data/src/stack_id.rs
@@ -1,6 +1,8 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Deserialize;
+use std::borrow::Borrow;
+use std::ops::Deref;
 use std::str::FromStr;
 
 /// Stack Id. This is a newtype wrapper around a String.
@@ -20,18 +22,45 @@ use std::str::FromStr;
 /// let invalid = StackId::from_str("!nvalid");
 /// assert!(invalid.is_err());
 ///
-/// let valid = StackId::from_str("*");
-/// assert!(valid.is_ok());
+/// // StackId implements various traits to improve interoperability. We can, for example, call
+/// // methods of String on StackId or pass it to functions that expect a String/str:
+/// let stack_id = "heroku-20".parse::<StackId>().unwrap();
+///
+/// assert_eq!("HEROKU-20", stack_id.to_uppercase());
+///
+/// fn length(s: &str) -> usize {
+///     s.len()
+/// }
+///
+/// assert_eq!(9, length(&stack_id));
 /// ```
 #[derive(Deserialize, Debug)]
 pub struct StackId(String);
 
-#[derive(thiserror::Error, Debug)]
-pub enum StackIdError {
-    #[error(
-    "Found `{0}` but value MUST only contain numbers, letters, and the characters `.`, `/`, and `-`. or only `*`"
-    )]
-    InvalidStackId(String),
+impl StackId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<String> for StackId {
+    fn borrow(&self) -> &String {
+        &self.0
+    }
+}
+
+impl Deref for StackId {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<String> for StackId {
+    fn as_ref(&self) -> &String {
+        &self.0
+    }
 }
 
 impl FromStr for StackId {
@@ -51,14 +80,10 @@ impl FromStr for StackId {
     }
 }
 
-impl From<StackId> for String {
-    fn from(stack_id: StackId) -> Self {
-        stack_id.0
-    }
-}
-
-impl StackId {
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
+#[derive(thiserror::Error, Debug)]
+pub enum StackIdError {
+    #[error(
+    "Found `{0}` but value MUST only contain numbers, letters, and the characters `.`, `/`, and `-`. or only `*`"
+    )]
+    InvalidStackId(String),
 }

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -3,6 +3,7 @@ use std::{fs, path::PathBuf};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use crate::data::stack_id::StackId;
 use crate::{
     data::{
         buildpack::BuildpackToml, buildpack_plan::BuildpackPlan, launch::Launch,
@@ -17,7 +18,7 @@ pub struct BuildContext<P: Platform, BM> {
     pub layers_dir: PathBuf,
     pub app_dir: PathBuf,
     pub buildpack_dir: PathBuf,
-    pub stack_id: String,
+    pub stack_id: StackId,
     pub platform: P,
     pub buildpack_plan: BuildpackPlan,
     pub buildpack_descriptor: BuildpackToml<BM>,

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -1,13 +1,14 @@
 use std::fmt::Debug;
 use std::path::PathBuf;
 
+use crate::data::stack_id::StackId;
 use crate::{data::build_plan::BuildPlan, data::buildpack::BuildpackToml, platform::Platform};
 
 /// Context for a buildpack's detect phase execution.
 pub struct DetectContext<P: Platform, BM> {
     pub app_dir: PathBuf,
     pub buildpack_dir: PathBuf,
-    pub stack_id: String,
+    pub stack_id: StackId,
     pub platform: P,
     pub buildpack_descriptor: BuildpackToml<BM>,
 }

--- a/libcnb/src/error.rs
+++ b/libcnb/src/error.rs
@@ -1,4 +1,5 @@
 use crate::data::launch::ProcessTypeError;
+use crate::data::stack_id::StackIdError;
 use crate::layer_lifecycle::LayerLifecycleError;
 use crate::toml_file::TomlFileError;
 use std::fmt::{Debug, Display};
@@ -42,6 +43,9 @@ pub enum Error<E: Debug + Display> {
 
     #[error("Cannot write build plan: {0}")]
     CannotWriteBuildPlan(TomlFileError),
+
+    #[error("Stack ID error: {0}")]
+    StackIdError(StackIdError),
 
     #[error("Buildpack error: {0}")]
     BuildpackError(E),

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -8,12 +8,14 @@ use serde::de::DeserializeOwned;
 
 use crate::build::BuildContext;
 use crate::data::buildpack::BuildpackToml;
+use crate::data::stack_id::StackId;
 use crate::detect::{DetectContext, DetectOutcome};
 use crate::error::{Error, ErrorHandler};
 use crate::platform::Platform;
 use crate::toml_file::{read_toml_file, write_toml_file};
 use crate::{Result, LIBCNB_SUPPORTED_BUILDPACK_API};
 use std::fmt::{Debug, Display};
+use std::str::FromStr;
 
 /// Main entry point for this framework.
 ///
@@ -112,7 +114,11 @@ fn cnb_runtime_detect<
 
     let app_dir = env::current_dir().map_err(Error::CannotDetermineAppDirectory)?;
 
-    let stack_id: String = env::var("CNB_STACK_ID").map_err(Error::CannotDetermineStackId)?;
+    let stack_id: StackId = env::var("CNB_STACK_ID")
+        .map_err(Error::CannotDetermineStackId)
+        .and_then(|stack_id_string| {
+            StackId::from_str(&stack_id_string).map_err(Error::StackIdError)
+        })?;
 
     let platform =
         P::from_path(&args.platform_dir_path).map_err(Error::CannotCreatePlatformFromPath)?;
@@ -150,7 +156,11 @@ fn cnb_runtime_build<
 
     let app_dir = env::current_dir().map_err(Error::CannotDetermineAppDirectory)?;
 
-    let stack_id: String = env::var("CNB_STACK_ID").map_err(Error::CannotDetermineStackId)?;
+    let stack_id: StackId = env::var("CNB_STACK_ID")
+        .map_err(Error::CannotDetermineStackId)
+        .and_then(|stack_id_string| {
+            StackId::from_str(&stack_id_string).map_err(Error::StackIdError)
+        })?;
 
     let platform =
         P::from_path(&args.platform_dir_path).map_err(Error::CannotCreatePlatformFromPath)?;


### PR DESCRIPTION
Previously, it was only used in the context of a buildpack.toml. StackIds are used in other contexts too and this PR generalizes them for other use-cases. In addtion, the type is now used in `BuildContext` and `DetectContext` instead of using a `String`.

In addition, this PR improves interoperability with `String` and `str` by implementing `Deref`, `Borrow` and `AsRef`. You can now use `StackId` interchangeably with `String` and `&str`. Examples:

```rust
let stack_id: StackId = "heroku-20".parse().unwrap();

assert_eq!("HEROKU-20", stack_id.to_uppercase());

fn length(s: &str) -> usize {
    s.len()
}

assert_eq!(9, length(&stack_id));
```

Other newtypes will get similar improvements in separate PRs.