### PR TITLE
Fix examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
     "libcnb",
-    "libcnb-data"
+    "libcnb-data",
+    "libcnb/examples/example-01-basics",
+    "libcnb/examples/example-02-ruby-sample"
 ]

--- a/libcnb/examples/example-02-ruby-sample/src/layers/bundler.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/bundler.rs
@@ -23,7 +23,7 @@ pub struct BundlerLayerMetadata {
 }
 
 impl LayerLifecycle<GenericPlatform, RubyBuildpackMetadata, BundlerLayerMetadata, Option<()>, anyhow::Error> for BundlerLayerLifecycle {
-    fn validate(&self, layer_path: &Path, layer_content_metadata: &LayerContentMetadata<BundlerLayerMetadata>, build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> ValidateResult {
+    fn validate(&self, _layer_path: &Path, layer_content_metadata: &LayerContentMetadata<BundlerLayerMetadata>, build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> ValidateResult {
         let checksum_matches = sha256_checksum(build_context.app_dir.join("Gemfile.lock"))
             .map(|local_checksum| local_checksum == layer_content_metadata.metadata.checksum)
             .unwrap_or(false);
@@ -35,7 +35,7 @@ impl LayerLifecycle<GenericPlatform, RubyBuildpackMetadata, BundlerLayerMetadata
         }
     }
 
-    fn update(&self, layer_path: &Path, layer_content_metadata: LayerContentMetadata<BundlerLayerMetadata>, build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> Result<LayerContentMetadata<BundlerLayerMetadata>, Error> {
+    fn update(&self, layer_path: &Path, layer_content_metadata: LayerContentMetadata<BundlerLayerMetadata>, _build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> Result<LayerContentMetadata<BundlerLayerMetadata>, Error> {
         println!("---> Reusing gems");
         Command::new("bundle")
             .args(&[

--- a/libcnb/examples/example-02-ruby-sample/src/layers/bundler.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/bundler.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 use std::process::Command;
 
 use anyhow::Error;
-use libcnb::{BuildContext, GenericPlatform};
 use libcnb::data::layer_content_metadata::LayerContentMetadata;
 use libcnb::layer_lifecycle::{LayerLifecycle, ValidateResult};
+use libcnb::{BuildContext, GenericPlatform};
 use serde::Deserialize;
 use serde::Serialize;
 use sha2::Digest;
@@ -22,8 +22,21 @@ pub struct BundlerLayerMetadata {
     checksum: String,
 }
 
-impl LayerLifecycle<GenericPlatform, RubyBuildpackMetadata, BundlerLayerMetadata, Option<()>, anyhow::Error> for BundlerLayerLifecycle {
-    fn validate(&self, _layer_path: &Path, layer_content_metadata: &LayerContentMetadata<BundlerLayerMetadata>, build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> ValidateResult {
+impl
+    LayerLifecycle<
+        GenericPlatform,
+        RubyBuildpackMetadata,
+        BundlerLayerMetadata,
+        Option<()>,
+        anyhow::Error,
+    > for BundlerLayerLifecycle
+{
+    fn validate(
+        &self,
+        _layer_path: &Path,
+        layer_content_metadata: &LayerContentMetadata<BundlerLayerMetadata>,
+        build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>,
+    ) -> ValidateResult {
         let checksum_matches = sha256_checksum(build_context.app_dir.join("Gemfile.lock"))
             .map(|local_checksum| local_checksum == layer_content_metadata.metadata.checksum)
             .unwrap_or(false);
@@ -35,15 +48,15 @@ impl LayerLifecycle<GenericPlatform, RubyBuildpackMetadata, BundlerLayerMetadata
         }
     }
 
-    fn update(&self, layer_path: &Path, layer_content_metadata: LayerContentMetadata<BundlerLayerMetadata>, _build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> Result<LayerContentMetadata<BundlerLayerMetadata>, Error> {
+    fn update(
+        &self,
+        layer_path: &Path,
+        layer_content_metadata: LayerContentMetadata<BundlerLayerMetadata>,
+        _build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>,
+    ) -> Result<LayerContentMetadata<BundlerLayerMetadata>, Error> {
         println!("---> Reusing gems");
         Command::new("bundle")
-            .args(&[
-                "config",
-                "--local",
-                "path",
-                layer_path.to_str().unwrap(),
-            ])
+            .args(&["config", "--local", "path", layer_path.to_str().unwrap()])
             .envs(&self.ruby_env)
             .spawn()?
             .wait()?;
@@ -62,7 +75,11 @@ impl LayerLifecycle<GenericPlatform, RubyBuildpackMetadata, BundlerLayerMetadata
         Ok(layer_content_metadata)
     }
 
-    fn create(&self, layer_path: &Path, build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> Result<LayerContentMetadata<BundlerLayerMetadata>, Error> {
+    fn create(
+        &self,
+        layer_path: &Path,
+        build_context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>,
+    ) -> Result<LayerContentMetadata<BundlerLayerMetadata>, Error> {
         println!("---> Installing gems");
 
         let cmd = Command::new("bundle")
@@ -80,9 +97,12 @@ impl LayerLifecycle<GenericPlatform, RubyBuildpackMetadata, BundlerLayerMetadata
             anyhow::anyhow!("Could not bundle install");
         }
 
-        Ok(LayerContentMetadata::default().launch(true).cache(true).metadata(BundlerLayerMetadata {
-            checksum: sha256_checksum(build_context.app_dir.join("Gemfile.lock"))?
-        }))
+        Ok(LayerContentMetadata::default()
+            .launch(true)
+            .cache(true)
+            .metadata(BundlerLayerMetadata {
+                checksum: sha256_checksum(build_context.app_dir.join("Gemfile.lock"))?,
+            }))
     }
 }
 

--- a/libcnb/examples/example-02-ruby-sample/src/layers/mod.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/mod.rs
@@ -1,2 +1,2 @@
-pub mod ruby;
 pub mod bundler;
+pub mod ruby;

--- a/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
@@ -8,7 +8,7 @@ use flate2::read::GzDecoder;
 use libcnb::data::layer_content_metadata::LayerContentMetadata;
 use libcnb::layer_lifecycle::LayerLifecycle;
 use libcnb::{BuildContext, GenericMetadata, GenericPlatform};
-use serde::{Deserialize, Serialize};
+
 use std::env;
 use tar::Archive;
 use tempfile::NamedTempFile;
@@ -46,7 +46,7 @@ impl
     fn layer_lifecycle_data(
         &self,
         layer_path: &Path,
-        layer_content_metadata: LayerContentMetadata<GenericMetadata>,
+        _layer_content_metadata: LayerContentMetadata<GenericMetadata>,
     ) -> Result<HashMap<String, String>, Error> {
         let mut ruby_env: HashMap<String, String> = HashMap::new();
         let ruby_bin_path = format!(

--- a/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
@@ -51,7 +51,7 @@ impl
         let mut ruby_env: HashMap<String, String> = HashMap::new();
         let ruby_bin_path = format!(
             "{}/.gem/ruby/2.6.6/bin",
-            env::var("HOME").unwrap_or(String::new())
+            env::var("HOME").unwrap_or_default()
         );
 
         ruby_env.insert(
@@ -60,7 +60,7 @@ impl
                 "{}:{}:{}",
                 layer_path.join("bin").as_path().to_str().unwrap(),
                 ruby_bin_path,
-                env::var("PATH").unwrap_or(String::new()),
+                env::var("PATH").unwrap_or_default(),
             ),
         );
 
@@ -68,7 +68,7 @@ impl
             String::from("LD_LIBRARY_PATH"),
             format!(
                 "{}:{}",
-                env::var("LD_LIBRARY_PATH").unwrap_or(String::new()),
+                env::var("LD_LIBRARY_PATH").unwrap_or_default(),
                 layer_path.join("layer").as_path().to_str().unwrap()
             ),
         );

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -43,7 +43,7 @@ fn build(
     install_bundler(&ruby_env)?;
     execute_layer_lifecycle("bundler", BundlerLayerLifecycle { ruby_env }, &context)?;
 
-    write_launch(&context);
+    write_launch(&context)?;
     Ok(())
 }
 

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::process::{Command, Stdio};
 
-use anyhow::Error;
+
 use libcnb::data;
 use libcnb::data::build_plan::BuildPlan;
 use libcnb::layer_lifecycle::execute_layer_lifecycle;
@@ -11,7 +11,7 @@ use libcnb::{
 use serde::Deserialize;
 
 use crate::layers::bundler::BundlerLayerLifecycle;
-use crate::layers::ruby;
+
 use crate::layers::ruby::RubyLayerLifecycle;
 
 mod layers;

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::process::{Command, Stdio};
 
-
 use libcnb::data;
 use libcnb::data::build_plan::BuildPlan;
 use libcnb::layer_lifecycle::execute_layer_lifecycle;

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -2,10 +2,12 @@ use std::collections::HashMap;
 use std::process::{Command, Stdio};
 
 use anyhow::Error;
-use libcnb::{BuildContext, cnb_runtime, DetectContext, DetectOutcome, GenericErrorHandler, GenericPlatform};
-use libcnb::data::build_plan::BuildPlan;
 use libcnb::data;
+use libcnb::data::build_plan::BuildPlan;
 use libcnb::layer_lifecycle::execute_layer_lifecycle;
+use libcnb::{
+    cnb_runtime, BuildContext, DetectContext, DetectOutcome, GenericErrorHandler, GenericPlatform,
+};
 use serde::Deserialize;
 
 use crate::layers::bundler::BundlerLayerLifecycle;
@@ -18,7 +20,9 @@ fn main() {
     cnb_runtime(detect, build, GenericErrorHandler)
 }
 
-fn detect(context: DetectContext<GenericPlatform, RubyBuildpackMetadata>) -> libcnb::Result<DetectOutcome, anyhow::Error> {
+fn detect(
+    context: DetectContext<GenericPlatform, RubyBuildpackMetadata>,
+) -> libcnb::Result<DetectOutcome, anyhow::Error> {
     let outcome = if context.app_dir.join("Gemfile.lock").exists() {
         DetectOutcome::Pass(BuildPlan::new())
     } else {
@@ -28,7 +32,9 @@ fn detect(context: DetectContext<GenericPlatform, RubyBuildpackMetadata>) -> lib
     Ok(outcome)
 }
 
-fn build(context: BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> libcnb::Result<(), anyhow::Error> {
+fn build(
+    context: BuildContext<GenericPlatform, RubyBuildpackMetadata>,
+) -> libcnb::Result<(), anyhow::Error> {
     println!("---> Ruby Buildpack");
     println!("---> Download and extracting Ruby");
 
@@ -63,11 +69,21 @@ fn install_bundler(ruby_env: &HashMap<String, String>) -> anyhow::Result<()> {
     }
 }
 
-fn write_launch(context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>) -> anyhow::Result<()> {
+fn write_launch(
+    context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>,
+) -> anyhow::Result<()> {
     let mut launch_toml = data::launch::Launch::new();
-    let web = data::launch::Process::new("web", "bundle", vec!["exec", "ruby", "app.rb"], false)?;
-    let worker =
-        data::launch::Process::new("worker", "bundle", vec!["exec", "ruby", "worker.rb"], false)?;
+    let web =
+        data::launch::Process::new("web", "bundle", vec!["exec", "ruby", "app.rb"], false, true)?;
+
+    let worker = data::launch::Process::new(
+        "worker",
+        "bundle",
+        vec!["exec", "ruby", "worker.rb"],
+        false,
+        false,
+    )?;
+
     launch_toml.processes.push(web);
     launch_toml.processes.push(worker);
 


### PR DESCRIPTION
#125 broke the examples by omitting them from the workspace. This PR fixes this.

This results in the examples being build on CI, which is great and wasn't done before. But that revealed that they no longer compile and/or lint correctly. This was fixed as well.