### PR TITLE
Reduce amount of explicit type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,6 @@
 - The `data` module can now be used without the rest of the framework by depending on the `libcnb-data` crate.
 - Introduced `Buildpack` trait that needs to be implemented for each buildpack
 - `cnb_runtime()` now requires a `Buildpack` instead of `detect` and `build` functions.
-- `ErrorHandler` has been removed. Functionality is not part of the new `Buildpack` type.
+- `ErrorHandler` has been removed. Functionality is now part of the new `Buildpack` type.
 
 ## [0.3.0] 2021/09/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,6 @@
 - The `data` module can now be used without the rest of the framework by depending on the `libcnb-data` crate.
 - Introduced `Buildpack` trait that needs to be implemented for each buildpack
 - `cnb_runtime()` now requires a `Buildpack` instead of `detect` and `build` functions.
-- `ErrorHandler` has been removed. Functionality is now part of the new `Buildpack` type.
+- `ErrorHandler` has been removed. Functionality is now part of the new `Buildpack` trait.
 
 ## [0.3.0] 2021/09/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,8 @@
 - Allow ProcessType to contain a dot (`.`) character
 - libcnb now targets [Buildpack API 0.6](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.6) <https://github.com/Malax/libcnb.rs/milestone/2>
 - The `data` module can now be used without the rest of the framework by depending on the `libcnb-data` crate.
+- Introduced `Buildpack` trait that needs to be implemented for each buildpack
+- `cnb_runtime()` now requires a `Buildpack` instead of `detect` and `build` functions.
+- `ErrorHandler` has been removed. Functionality is not part of the new `Buildpack` type.
 
 ## [0.3.0] 2021/09/17

--- a/libcnb/examples/example-01-basics/src/main.rs
+++ b/libcnb/examples/example-01-basics/src/main.rs
@@ -1,19 +1,25 @@
 use libcnb::data::build_plan::BuildPlan;
 use libcnb::{
-    cnb_runtime, DetectOutcome, GenericBuildContext, GenericDetectContext, GenericErrorHandler,
-    Result,
+    cnb_runtime, BuildContext, Buildpack, DetectContext, DetectOutcome, GenericError,
+    GenericMetadata, GenericPlatform,
 };
 
+struct BasicBuildpack;
+impl Buildpack for BasicBuildpack {
+    type Platform = GenericPlatform;
+    type Metadata = GenericMetadata;
+    type Error = GenericError;
+
+    fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectOutcome, Self::Error> {
+        Ok(DetectOutcome::Pass(BuildPlan::new()))
+    }
+
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<(), Self::Error> {
+        println!("Build runs on stack {}!", context.stack_id);
+        Ok(())
+    }
+}
+
 fn main() {
-    cnb_runtime(detect, build, GenericErrorHandler);
-}
-
-fn detect(_context: GenericDetectContext) -> Result<DetectOutcome, std::io::Error> {
-    let buildplan = BuildPlan::new();
-    Ok(DetectOutcome::Pass(buildplan))
-}
-
-fn build(context: GenericBuildContext) -> Result<(), std::io::Error> {
-    println!("Build runs on stack {}!", context.stack_id);
-    Ok(())
+    cnb_runtime(BasicBuildpack);
 }

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -1,50 +1,48 @@
 use std::collections::HashMap;
 use std::process::{Command, Stdio};
 
-use libcnb::data;
+use crate::layers::bundler::BundlerLayerLifecycle;
+use crate::layers::ruby::RubyLayerLifecycle;
 use libcnb::data::build_plan::BuildPlan;
 use libcnb::layer_lifecycle::execute_layer_lifecycle;
-use libcnb::{
-    cnb_runtime, BuildContext, DetectContext, DetectOutcome, GenericErrorHandler, GenericPlatform,
-};
+use libcnb::{cnb_runtime, BuildContext, DetectContext, DetectOutcome, GenericPlatform};
+use libcnb::{data, Buildpack};
 use serde::Deserialize;
-
-use crate::layers::bundler::BundlerLayerLifecycle;
-
-use crate::layers::ruby::RubyLayerLifecycle;
-
 mod layers;
 
+struct RubyBuildpack;
+impl Buildpack for RubyBuildpack {
+    type Platform = GenericPlatform;
+    type Metadata = RubyBuildpackMetadata;
+    type Error = anyhow::Error;
+
+    fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectOutcome, Self::Error> {
+        let outcome = if context.app_dir.join("Gemfile.lock").exists() {
+            DetectOutcome::Pass(BuildPlan::new())
+        } else {
+            DetectOutcome::Fail
+        };
+
+        Ok(outcome)
+    }
+
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<(), Self::Error> {
+        println!("---> Ruby Buildpack");
+        println!("---> Download and extracting Ruby");
+
+        let ruby_env = execute_layer_lifecycle("ruby", RubyLayerLifecycle, &context)?;
+
+        println!("---> Installing bundler");
+        install_bundler(&ruby_env)?;
+        execute_layer_lifecycle("bundler", BundlerLayerLifecycle { ruby_env }, &context)?;
+
+        write_launch(&context)?;
+        Ok(())
+    }
+}
+
 fn main() {
-    cnb_runtime(detect, build, GenericErrorHandler)
-}
-
-fn detect(
-    context: DetectContext<GenericPlatform, RubyBuildpackMetadata>,
-) -> libcnb::Result<DetectOutcome, anyhow::Error> {
-    let outcome = if context.app_dir.join("Gemfile.lock").exists() {
-        DetectOutcome::Pass(BuildPlan::new())
-    } else {
-        DetectOutcome::Fail
-    };
-
-    Ok(outcome)
-}
-
-fn build(
-    context: BuildContext<GenericPlatform, RubyBuildpackMetadata>,
-) -> libcnb::Result<(), anyhow::Error> {
-    println!("---> Ruby Buildpack");
-    println!("---> Download and extracting Ruby");
-
-    let ruby_env = execute_layer_lifecycle("ruby", RubyLayerLifecycle, &context)?;
-
-    println!("---> Installing bundler");
-    install_bundler(&ruby_env)?;
-    execute_layer_lifecycle("bundler", BundlerLayerLifecycle { ruby_env }, &context)?;
-
-    write_launch(&context)?;
-    Ok(())
+    cnb_runtime(RubyBuildpack)
 }
 
 #[derive(Deserialize, Debug)]
@@ -68,9 +66,7 @@ fn install_bundler(ruby_env: &HashMap<String, String>) -> anyhow::Result<()> {
     }
 }
 
-fn write_launch(
-    context: &BuildContext<GenericPlatform, RubyBuildpackMetadata>,
-) -> anyhow::Result<()> {
+fn write_launch<B: Buildpack>(context: &BuildContext<B>) -> anyhow::Result<()> {
     let mut launch_toml = data::launch::Launch::new();
     let web =
         data::launch::Process::new("web", "bundle", vec!["exec", "ruby", "app.rb"], false, true)?;

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -3,27 +3,27 @@ use std::{fs, path::PathBuf};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use crate::buildpack::Buildpack;
 use crate::{
     data::{
         buildpack::BuildpackToml, buildpack_plan::BuildpackPlan, launch::Launch,
         layer_content_metadata::LayerContentMetadata,
     },
-    platform::Platform,
     toml_file::{read_toml_file, write_toml_file, TomlFileError},
 };
 
 /// Context for a buildpack's build phase execution.
-pub struct BuildContext<P: Platform, BM> {
+pub struct BuildContext<B: Buildpack + ?Sized> {
     pub layers_dir: PathBuf,
     pub app_dir: PathBuf,
     pub buildpack_dir: PathBuf,
     pub stack_id: String,
-    pub platform: P,
+    pub platform: B::Platform,
     pub buildpack_plan: BuildpackPlan,
-    pub buildpack_descriptor: BuildpackToml<BM>,
+    pub buildpack_descriptor: BuildpackToml<B::Metadata>,
 }
 
-impl<P: Platform, BM> BuildContext<P, BM> {
+impl<B: Buildpack> BuildContext<B> {
     pub fn layer_path(&self, layer_name: impl AsRef<str>) -> PathBuf {
         self.layers_dir.join(layer_name.as_ref())
     }

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -1,0 +1,20 @@
+use crate::{BuildContext, DetectContext, DetectOutcome, Platform};
+use serde::de::DeserializeOwned;
+use std::fmt::{Debug, Display};
+
+pub trait Buildpack {
+    type Platform: Platform;
+    type Metadata: DeserializeOwned;
+    type Error: Debug + Display;
+
+    fn detect(&self, context: DetectContext<Self>) -> crate::Result<DetectOutcome, Self::Error>;
+
+    fn build(&self, context: BuildContext<Self>) -> crate::Result<(), Self::Error>;
+
+    fn handle_error(&self, error: crate::Error<Self::Error>) -> i32 {
+        eprintln!("Unhandled error:");
+        eprintln!("> {}", error);
+        eprintln!("Buildpack will exit!");
+        100
+    }
+}

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -1,15 +1,16 @@
 use std::fmt::Debug;
 use std::path::PathBuf;
 
-use crate::{data::build_plan::BuildPlan, data::buildpack::BuildpackToml, platform::Platform};
+use crate::buildpack::Buildpack;
+use crate::{data::build_plan::BuildPlan, data::buildpack::BuildpackToml};
 
 /// Context for a buildpack's detect phase execution.
-pub struct DetectContext<P: Platform, BM> {
+pub struct DetectContext<B: Buildpack + ?Sized> {
     pub app_dir: PathBuf,
     pub buildpack_dir: PathBuf,
     pub stack_id: String,
-    pub platform: P,
-    pub buildpack_descriptor: BuildpackToml<BM>,
+    pub platform: B::Platform,
+    pub buildpack_descriptor: BuildpackToml<B::Metadata>,
 }
 
 /// Describes the outcome of the buildpack's detect phase.

--- a/libcnb/src/error.rs
+++ b/libcnb/src/error.rs
@@ -3,11 +3,6 @@ use crate::layer_lifecycle::LayerLifecycleError;
 use crate::toml_file::TomlFileError;
 use std::fmt::{Debug, Display};
 
-/// Handles top-level buildpack errors.
-pub trait ErrorHandler<E: Debug + Display> {
-    fn handle_error(&self, error: Error<E>) -> i32;
-}
-
 /// A specialized Result type for libcnb.
 ///
 /// This type is broadly used across libcnb for any operation which may produce an error.

--- a/libcnb/src/generic.rs
+++ b/libcnb/src/generic.rs
@@ -1,22 +1,22 @@
 use std::path::Path;
 
-use crate::build::BuildContext;
-use crate::detect::DetectContext;
-use crate::error::{Error, ErrorHandler};
 use crate::platform::{Platform, PlatformEnv};
-use std::fmt::{Debug, Display};
+use std::fmt::{Debug, Display, Formatter};
 
 /// Generic TOML metadata.
 pub type GenericMetadata = Option<toml::value::Table>;
 
-/// A build context for a buildpack that uses a generic platform and metadata.
-pub type GenericBuildContext = BuildContext<GenericPlatform, GenericMetadata>;
-
-/// A build detect for a buildpack that uses a generic platform and metadata.
-pub type GenericDetectContext = DetectContext<GenericPlatform, GenericMetadata>;
-
 /// Generic output type for layer lifecycles.
 pub type GenericLayerLifecycleOutput = ();
+
+#[derive(Debug)]
+pub enum GenericError {}
+
+impl Display for GenericError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("GenericError")
+    }
+}
 
 /// A generic platform that only provides access to environment variables.
 pub struct GenericPlatform {
@@ -32,17 +32,5 @@ impl Platform for GenericPlatform {
         Ok(Self {
             env: PlatformEnv::from_path(platform_dir)?,
         })
-    }
-}
-
-/// Generic implementation of [`ErrorHandler`] that logs errors on stderr based on their [`Display`](std::fmt::Display) representation.
-pub struct GenericErrorHandler;
-
-impl<E: Debug + Display> ErrorHandler<E> for GenericErrorHandler {
-    fn handle_error(&self, error: Error<E>) -> i32 {
-        eprintln!("Unhandled error:");
-        eprintln!("> {}", error);
-        eprintln!("Buildpack will exit!");
-        100
     }
 }

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -33,6 +33,7 @@ pub mod layer_lifecycle;
 
 use crate::data::buildpack::BuildpackApi;
 pub use build::BuildContext;
+pub use buildpack::Buildpack;
 pub use detect::DetectContext;
 pub use detect::DetectOutcome;
 pub use env::*;
@@ -44,6 +45,7 @@ pub use runtime::cnb_runtime;
 pub use toml_file::*;
 
 mod build;
+mod buildpack;
 mod detect;
 mod env;
 mod error;


### PR DESCRIPTION
By introducing a central type for the buildpack itself, we can leverage associated types to define other types that are valid throughout the buildpack. For example, the type for the buildpack metadata never changes. The same is true about the error type and the target platform. The code has been refactored to reference these associated types instead of requiring explicit values everywhere.