### PR TITLE
Update README and test it as a doctest

### DIFF
--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -55,3 +55,9 @@ mod runtime;
 mod toml_file;
 
 const LIBCNB_SUPPORTED_BUILDPACK_API: BuildpackApi = BuildpackApi { major: 0, minor: 6 };
+
+// This runs the README.md as a doctest, ensuring the code examples in it are valid.
+// It will not be part of the final crate.
+#[cfg(doctest)]
+#[doc = include_str!("../../README.md")]
+pub struct ReadmeDoctests;


### PR DESCRIPTION
This updates the projects `README.md`. It was horribly outdated. Wrong documentation is worse than no documentation. I changed some bits to reflect recent design changes (such as being opinionated) and expanded the hello world buildpack example with extra comments to clarify things.

To make sure the code in the README does not get outdated again, the README file is now included as a doctest in the libcnb code and will be run as such during CI. This should at least catch compile errors when the API changes.

Fixes #76
Fixes #92