### PR TITLE
Switch from reqwest to ureq in Ruby example

### DIFF
--- a/libcnb/examples/example-02-ruby-sample/Cargo.toml
+++ b/libcnb/examples/example-02-ruby-sample/Cargo.toml
@@ -8,11 +8,10 @@ rust-version = "1.56"
 [dependencies]
 anyhow = "1"
 flate2 = "1"
-reqwest = { version = "0.11", features = ["blocking"] }
+ureq = "2.2.1"
 sha2 = "0.9"
 tar = "0.4"
 toml = "0.5"
 tempfile = "3"
 "libcnb" = { path = "../..", features = ["anyhow"] }
 serde = "1.0.126"
-openssl = { version = "0.10.36", features = ["vendored"] }

--- a/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
@@ -72,10 +72,10 @@ impl LayerLifecycle<RubyBuildpack, GenericMetadata, HashMap<String, String>>
 }
 
 fn download(uri: impl AsRef<str>, dst: impl AsRef<Path>) -> anyhow::Result<()> {
-    let response = reqwest::blocking::get(uri.as_ref())?;
-    let mut content = io::Cursor::new(response.bytes()?);
+    let response = ureq::get(uri.as_ref()).call()?;
+    let mut reader = response.into_reader();
     let mut file = fs::File::create(dst.as_ref())?;
-    io::copy(&mut content, &mut file)?;
+    io::copy(&mut reader, &mut file)?;
 
     Ok(())
 }


### PR DESCRIPTION
Since we don't need `reqwest`'s additional features (such as async support), and `ureq`'s much smaller dependency tree reduces compile times and binary size substantially.

This helps with CI times for this repository, which cannot use caching since it is a library so doesn't have a lockfile to use for cache-busting.

This is equivalent to heroku/libherokubuildpack#22.