### PR TITLE
Add BuildResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
 - Introduced `Buildpack` trait that needs to be implemented for each buildpack
 - `cnb_runtime()` now requires a `Buildpack` instead of `detect` and `build` functions.
 - `ErrorHandler` has been removed. Functionality is now part of the new `Buildpack` trait.
-- `build` now returns `Result<BuildOutcome, E>` instead of `Result<(), E>`. Construct `BuildOutcome` values by using the new `BuildOutcomeBuilder`.
-- `DetectOutcome` is no longer an enum and needs to be constructed with a `DetectOutcomeBuilder`.
-- `BuildContext#write_launch` was removed. Return a `Launch` value from `build` via `BuildOutcome` instead.
+- `build` now returns `Result<BuildResult, E>` instead of `Result<(), E>`. Construct `BuildResult` values by using the new `BuildResultBuilder`.
+- `detect` now returns `DetectResult` instead of a `DetectOutcome` enum. Construct `DetectResult` values by using the new `DetectResultBuilder`.
+- `BuildContext#write_launch` was removed. Return a `Launch` value from `build` via `BuildResult` instead.
 
 ## [0.3.0] 2021/09/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,8 @@
 - Introduced `Buildpack` trait that needs to be implemented for each buildpack
 - `cnb_runtime()` now requires a `Buildpack` instead of `detect` and `build` functions.
 - `ErrorHandler` has been removed. Functionality is now part of the new `Buildpack` trait.
+- `build` now returns `Result<BuildOutcome, E>` instead of `Result<(), E>`. Construct `BuildOutcome` values by using the new `BuildOutcomeBuilder`.
+- `DetectOutcome` is no longer an enum and needs to be constructed with a `DetectOutcomeBuilder`.
+- `BuildContext#write_launch` was removed. Return a `Launch` value from `build` via `BuildOutcome` instead.
 
 ## [0.3.0] 2021/09/17

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ can be used without the framework to implement Cloud Native Buildpacks tooling i
 A basic hello world buildpack looks like this:
 
 ```rust,no_run
+use libcnb::build::{BuildContext, BuildOutcome, BuildOutcomeBuilder};
+use libcnb::detect::{DetectContext, DetectOutcome, DetectOutcomeBuilder};
 use libcnb::{
-    cnb_runtime, data::build_plan::BuildPlan, BuildContext, BuildOutcome, Buildpack, DetectContext,
-    DetectOutcome, GenericError, GenericMetadata, GenericPlatform,
+    cnb_runtime, data::build_plan::BuildPlan, Buildpack, GenericError, GenericMetadata,
+    GenericPlatform,
 };
 
 struct HelloWorldBuildpack;
@@ -46,15 +48,15 @@ impl Buildpack for HelloWorldBuildpack {
     // The CNB platform this buildpack targets, usually GenericPlatform. See the CNB spec for more information
     // about platforms: https://github.com/buildpacks/spec/blob/main/buildpack.md
     type Platform = GenericPlatform;
-    
+
     // The type for the metadata of the buildpack itself. This is the data found in the `[metadata]` section
     // of your buildpack's buildpack.toml. The framework will automatically try to parse it into the specified type.
     // This example buildpack uses GenericMetadata which provides low-level access to the TOML table.
     type Metadata = GenericMetadata;
-    
+
     // The error type for this buildpack. Buildpack authors usually implement an enum with specific errors that can
     // happen during buildpack execution. This error type should only contain error specific to this buildpack, such
-    // as CouldNotExecuteMaven or InvalidGemfileLock. This example buildpack uses GenericError which means this 
+    // as CouldNotExecuteMaven or InvalidGemfileLock. This example buildpack uses GenericError which means this
     // buildpack does not specify any errors.
     //
     // More generic errors that happen during buildpack execution such as I/O errors while writing CNB TOML files are
@@ -62,21 +64,21 @@ impl Buildpack for HelloWorldBuildpack {
     type Error = GenericError;
 
     // This method will be called when the CNB lifecycle calls detect. Use the DetectContext to access CNB data such as
-    // the stack this buildpack is currently executed on, the app directory and similar things. When using libcnb.rs, 
+    // the stack this buildpack is currently executed on, the app directory and similar things. When using libcnb.rs,
     // you never have to read environment variables or read/write files to disk to interact with the CNB lifecycle.
     //
     // One example of this is the return type of this method. DetectOutcome encapsulates the required exit code as well
-    // as the data written to the build plan. libcnb.rs will, according to the returned value, handle both writing the 
+    // as the data written to the build plan. libcnb.rs will, according to the returned value, handle both writing the
     // build plan and exiting with the correct status code for you.
     fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectOutcome, Self::Error> {
-        Ok(DetectOutcome::Pass(BuildPlan::new()))
+        Ok(DetectOutcomeBuilder::pass().build())
     }
 
     // Similar to detect, this method will be called when the CNB lifecycle executes the build phase.
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildOutcome, Self::Error> {
         println!("Hello World!");
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(BuildOutcome::success())
+        Ok(BuildOutcomeBuilder::success().build())
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ can be used without the framework to implement Cloud Native Buildpacks tooling i
 A basic hello world buildpack looks like this:
 
 ```rust,no_run
-use libcnb::build::{BuildContext, BuildOutcome, BuildOutcomeBuilder};
-use libcnb::detect::{DetectContext, DetectOutcome, DetectOutcomeBuilder};
+use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::{
     cnb_runtime, data::build_plan::BuildPlan, Buildpack, GenericError, GenericMetadata,
     GenericPlatform,
@@ -67,18 +67,18 @@ impl Buildpack for HelloWorldBuildpack {
     // the stack this buildpack is currently executed on, the app directory and similar things. When using libcnb.rs,
     // you never have to read environment variables or read/write files to disk to interact with the CNB lifecycle.
     //
-    // One example of this is the return type of this method. DetectOutcome encapsulates the required exit code as well
+    // One example of this is the return type of this method. DetectResult encapsulates the required exit code as well
     // as the data written to the build plan. libcnb.rs will, according to the returned value, handle both writing the
     // build plan and exiting with the correct status code for you.
-    fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectOutcome, Self::Error> {
-        Ok(DetectOutcomeBuilder::pass().build())
+    fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+        Ok(DetectResultBuilder::pass().build())
     }
 
     // Similar to detect, this method will be called when the CNB lifecycle executes the build phase.
-    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildOutcome, Self::Error> {
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         println!("Hello World!");
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(BuildOutcomeBuilder::new().build())
+        Ok(BuildResultBuilder::new().build())
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A basic hello world buildpack looks like this:
 
 ```rust,no_run
 use libcnb::{
-    cnb_runtime, data::build_plan::BuildPlan, BuildContext, Buildpack, DetectContext,
+    cnb_runtime, data::build_plan::BuildPlan, BuildContext, BuildOutcome, Buildpack, DetectContext,
     DetectOutcome, GenericError, GenericMetadata, GenericPlatform,
 };
 
@@ -73,10 +73,10 @@ impl Buildpack for HelloWorldBuildpack {
     }
 
     // Similar to detect, this method will be called when the CNB lifecycle executes the build phase.
-    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<(), Self::Error> {
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildOutcome, Self::Error> {
         println!("Hello World!");
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(())
+        Ok(BuildOutcome::success())
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ impl Buildpack for HelloWorldBuildpack {
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildOutcome, Self::Error> {
         println!("Hello World!");
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(BuildOutcomeBuilder::success().build())
+        Ok(BuildOutcomeBuilder::new().build())
     }
 }
 

--- a/libcnb/examples/example-01-basics/src/main.rs
+++ b/libcnb/examples/example-01-basics/src/main.rs
@@ -1,8 +1,6 @@
-use libcnb::data::build_plan::BuildPlan;
-use libcnb::{
-    cnb_runtime, BuildContext, BuildOutcome, Buildpack, DetectContext, DetectOutcome, GenericError,
-    GenericMetadata, GenericPlatform,
-};
+use libcnb::build::{BuildContext, BuildOutcome, BuildOutcomeBuilder};
+use libcnb::detect::{DetectContext, DetectOutcome, DetectOutcomeBuilder};
+use libcnb::{cnb_runtime, Buildpack, GenericError, GenericMetadata, GenericPlatform};
 
 struct BasicBuildpack;
 impl Buildpack for BasicBuildpack {
@@ -11,12 +9,12 @@ impl Buildpack for BasicBuildpack {
     type Error = GenericError;
 
     fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectOutcome, Self::Error> {
-        Ok(DetectOutcome::Pass(BuildPlan::new()))
+        Ok(DetectOutcomeBuilder::pass().build())
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildOutcome, Self::Error> {
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(BuildOutcome::success())
+        Ok(BuildOutcomeBuilder::success().build())
     }
 }
 

--- a/libcnb/examples/example-01-basics/src/main.rs
+++ b/libcnb/examples/example-01-basics/src/main.rs
@@ -1,6 +1,6 @@
 use libcnb::data::build_plan::BuildPlan;
 use libcnb::{
-    cnb_runtime, BuildContext, Buildpack, DetectContext, DetectOutcome, GenericError,
+    cnb_runtime, BuildContext, BuildOutcome, Buildpack, DetectContext, DetectOutcome, GenericError,
     GenericMetadata, GenericPlatform,
 };
 
@@ -14,9 +14,9 @@ impl Buildpack for BasicBuildpack {
         Ok(DetectOutcome::Pass(BuildPlan::new()))
     }
 
-    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<(), Self::Error> {
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildOutcome, Self::Error> {
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(())
+        Ok(BuildOutcome::success())
     }
 }
 

--- a/libcnb/examples/example-01-basics/src/main.rs
+++ b/libcnb/examples/example-01-basics/src/main.rs
@@ -14,7 +14,7 @@ impl Buildpack for BasicBuildpack {
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildOutcome, Self::Error> {
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(BuildOutcomeBuilder::success().build())
+        Ok(BuildOutcomeBuilder::new().build())
     }
 }
 

--- a/libcnb/examples/example-01-basics/src/main.rs
+++ b/libcnb/examples/example-01-basics/src/main.rs
@@ -1,5 +1,5 @@
-use libcnb::build::{BuildContext, BuildOutcome, BuildOutcomeBuilder};
-use libcnb::detect::{DetectContext, DetectOutcome, DetectOutcomeBuilder};
+use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::{cnb_runtime, Buildpack, GenericError, GenericMetadata, GenericPlatform};
 
 struct BasicBuildpack;
@@ -8,13 +8,13 @@ impl Buildpack for BasicBuildpack {
     type Metadata = GenericMetadata;
     type Error = GenericError;
 
-    fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectOutcome, Self::Error> {
-        Ok(DetectOutcomeBuilder::pass().build())
+    fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+        Ok(DetectResultBuilder::pass().build())
     }
 
-    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildOutcome, Self::Error> {
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(BuildOutcomeBuilder::new().build())
+        Ok(BuildResultBuilder::new().build())
     }
 }
 

--- a/libcnb/examples/example-02-ruby-sample/src/layers/bundler.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/bundler.rs
@@ -5,12 +5,12 @@ use std::process::Command;
 
 use libcnb::data::layer_content_metadata::LayerContentMetadata;
 use libcnb::layer_lifecycle::{LayerLifecycle, ValidateResult};
-use libcnb::BuildContext;
 use serde::Deserialize;
 use serde::Serialize;
 use sha2::Digest;
 
 use crate::RubyBuildpack;
+use libcnb::build::BuildContext;
 
 pub struct BundlerLayerLifecycle {
     pub ruby_env: HashMap<String, String>,

--- a/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
@@ -6,13 +6,14 @@ use std::path::Path;
 use flate2::read::GzDecoder;
 use libcnb::data::layer_content_metadata::LayerContentMetadata;
 use libcnb::layer_lifecycle::LayerLifecycle;
-use libcnb::{BuildContext, GenericMetadata};
+use libcnb::GenericMetadata;
 
 use std::env;
 use tar::Archive;
 use tempfile::NamedTempFile;
 
 use crate::RubyBuildpack;
+use libcnb::build::BuildContext;
 
 pub struct RubyLayerLifecycle;
 

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -39,7 +39,7 @@ impl Buildpack for RubyBuildpack {
         install_bundler(&ruby_env)?;
         execute_layer_lifecycle("bundler", BundlerLayerLifecycle { ruby_env }, &context)?;
 
-        Ok(BuildOutcomeBuilder::success()
+        Ok(BuildOutcomeBuilder::new()
             .launch(
                 Launch::new()
                     .process(Process::new(

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -3,9 +3,9 @@ use std::process::{Command, Stdio};
 
 use crate::layers::bundler::BundlerLayerLifecycle;
 use crate::layers::ruby::RubyLayerLifecycle;
-use libcnb::build::{BuildContext, BuildOutcome, BuildOutcomeBuilder};
+use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::launch::{Launch, Process};
-use libcnb::detect::{DetectContext, DetectOutcome, DetectOutcomeBuilder};
+use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::layer_lifecycle::execute_layer_lifecycle;
 use libcnb::Buildpack;
 use libcnb::{cnb_runtime, GenericPlatform};
@@ -19,17 +19,17 @@ impl Buildpack for RubyBuildpack {
     type Metadata = RubyBuildpackMetadata;
     type Error = anyhow::Error;
 
-    fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectOutcome, Self::Error> {
-        let outcome = if context.app_dir.join("Gemfile.lock").exists() {
-            DetectOutcomeBuilder::pass().build()
+    fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+        let result = if context.app_dir.join("Gemfile.lock").exists() {
+            DetectResultBuilder::pass().build()
         } else {
-            DetectOutcomeBuilder::fail().build()
+            DetectResultBuilder::fail().build()
         };
 
-        Ok(outcome)
+        Ok(result)
     }
 
-    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildOutcome, Self::Error> {
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         println!("---> Ruby Buildpack");
         println!("---> Download and extracting Ruby");
 
@@ -39,7 +39,7 @@ impl Buildpack for RubyBuildpack {
         install_bundler(&ruby_env)?;
         execute_layer_lifecycle("bundler", BundlerLayerLifecycle { ruby_env }, &context)?;
 
-        Ok(BuildOutcomeBuilder::new()
+        Ok(BuildResultBuilder::new()
             .launch(
                 Launch::new()
                     .process(Process::new(

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -24,45 +24,45 @@ pub struct BuildContext<B: Buildpack + ?Sized> {
     pub buildpack_descriptor: BuildpackToml<B::Metadata>,
 }
 
-/// Describes the outcome of the build phase.
+/// Describes the result of the build phase.
 ///
-/// In contrast to `DetectOutcome`, it always signals a successful build. To fail the build phase,
-/// return a failed result from the build function.
+/// In contrast to `DetectResult`, it always signals a successful build. To fail the build phase,
+/// return a failed [`libcnb::Result`] from the build function.
 ///
 /// It contains build phase output such as launch and/or store metadata which will be subsequently
 /// handled by libcnb.
 ///
-/// To construct values of this type, use a [`BuildOutcomeBuilder`].
+/// To construct values of this type, use a [`BuildResultBuilder`].
 #[derive(Debug)]
-pub struct BuildOutcome(pub(crate) InnerBuildOutcome);
+pub struct BuildResult(pub(crate) InnerBuildResult);
 
 #[derive(Debug)]
-pub(crate) enum InnerBuildOutcome {
+pub(crate) enum InnerBuildResult {
     Pass {
         launch: Option<Launch>,
         store: Option<Store>,
     },
 }
 
-/// Constructs [`BuildOutcome`] values.
+/// Constructs [`BuildResult`] values.
 ///
 /// # Examples:
 /// ```
-/// use libcnb::build::BuildOutcomeBuilder;
+/// use libcnb::build::BuildResultBuilder;
 /// use libcnb_data::launch::{Launch, Process};
 ///
-/// let simple = BuildOutcomeBuilder::new().build();
+/// let simple = BuildResultBuilder::new().build();
 ///
-/// let with_launch = BuildOutcomeBuilder::new()
+/// let with_launch = BuildResultBuilder::new()
 ///    .launch(Launch::new().process(Process::new("type", "command", vec!["-v"], false, false).unwrap()))
 ///    .build();
 /// ```
-pub struct BuildOutcomeBuilder {
+pub struct BuildResultBuilder {
     launch: Option<Launch>,
     store: Option<Store>,
 }
 
-impl BuildOutcomeBuilder {
+impl BuildResultBuilder {
     pub fn new() -> Self {
         Self {
             launch: None,
@@ -71,9 +71,9 @@ impl BuildOutcomeBuilder {
     }
 }
 
-impl BuildOutcomeBuilder {
-    pub fn build(self) -> BuildOutcome {
-        BuildOutcome(InnerBuildOutcome::Pass {
+impl BuildResultBuilder {
+    pub fn build(self) -> BuildResult {
+        BuildResult(InnerBuildResult::Pass {
             launch: self.launch,
             store: self.store,
         })
@@ -90,7 +90,7 @@ impl BuildOutcomeBuilder {
     }
 }
 
-impl Default for BuildOutcomeBuilder {
+impl Default for BuildResultBuilder {
     fn default() -> Self {
         Self::new()
     }

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -96,6 +96,7 @@ impl SuccessBuildOutcomeBuilder {
 pub struct FailBuildOutcomeBuilder;
 
 impl FailBuildOutcomeBuilder {
+    #[allow(clippy::unused_self)]
     pub fn build(self) -> BuildOutcome {
         BuildOutcome(InnerBuildOutcome::Fail)
     }

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -1,4 +1,4 @@
-use crate::{BuildContext, DetectContext, DetectOutcome, Platform};
+use crate::{BuildContext, BuildOutcome, DetectContext, DetectOutcome, Platform};
 use serde::de::DeserializeOwned;
 use std::fmt::{Debug, Display};
 
@@ -9,7 +9,7 @@ pub trait Buildpack {
 
     fn detect(&self, context: DetectContext<Self>) -> crate::Result<DetectOutcome, Self::Error>;
 
-    fn build(&self, context: BuildContext<Self>) -> crate::Result<(), Self::Error>;
+    fn build(&self, context: BuildContext<Self>) -> crate::Result<BuildOutcome, Self::Error>;
 
     fn handle_error(&self, error: crate::Error<Self::Error>) -> i32 {
         eprintln!("Unhandled error:");

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -1,5 +1,5 @@
-use crate::build::{BuildContext, BuildOutcome};
-use crate::detect::{DetectContext, DetectOutcome};
+use crate::build::{BuildContext, BuildResult};
+use crate::detect::{DetectContext, DetectResult};
 use crate::Platform;
 use serde::de::DeserializeOwned;
 use std::fmt::{Debug, Display};
@@ -9,9 +9,9 @@ pub trait Buildpack {
     type Metadata: DeserializeOwned;
     type Error: Debug + Display;
 
-    fn detect(&self, context: DetectContext<Self>) -> crate::Result<DetectOutcome, Self::Error>;
+    fn detect(&self, context: DetectContext<Self>) -> crate::Result<DetectResult, Self::Error>;
 
-    fn build(&self, context: BuildContext<Self>) -> crate::Result<BuildOutcome, Self::Error>;
+    fn build(&self, context: BuildContext<Self>) -> crate::Result<BuildResult, Self::Error>;
 
     fn handle_error(&self, error: crate::Error<Self::Error>) -> i32 {
         eprintln!("Unhandled error:");

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -1,4 +1,6 @@
-use crate::{BuildContext, BuildOutcome, DetectContext, DetectOutcome, Platform};
+use crate::build::{BuildContext, BuildOutcome};
+use crate::detect::{DetectContext, DetectOutcome};
+use crate::Platform;
 use serde::de::DeserializeOwned;
 use std::fmt::{Debug, Display};
 

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -72,6 +72,7 @@ impl PassDetectOutcomeBuilder {
 pub struct FailDetectOutcomeBuilder;
 
 impl FailDetectOutcomeBuilder {
+    #[allow(clippy::unused_self)]
     pub fn build(self) -> DetectOutcome {
         DetectOutcome(InnerDetectOutcome::Fail)
     }

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::buildpack::Buildpack;
 use crate::{data::build_plan::BuildPlan, data::buildpack::BuildpackToml};
 
-/// Context for a buildpack's detect phase execution.
+/// Context for the detect phase execution.
 pub struct DetectContext<B: Buildpack + ?Sized> {
     pub app_dir: PathBuf,
     pub buildpack_dir: PathBuf,
@@ -13,9 +13,66 @@ pub struct DetectContext<B: Buildpack + ?Sized> {
     pub buildpack_descriptor: BuildpackToml<B::Metadata>,
 }
 
-/// Describes the outcome of the buildpack's detect phase.
+/// Describes the outcome of the detect phase.
+///
+/// Besides indicating passing or failing detection, it also contains detect phase output such as
+/// the build plan. To construct values of this type, use a [`DetectOutcomeBuilder`].
 #[derive(Debug)]
-pub enum DetectOutcome {
-    Pass(BuildPlan),
+pub struct DetectOutcome(pub(crate) InnerDetectOutcome);
+
+#[derive(Debug)]
+pub(crate) enum InnerDetectOutcome {
     Fail,
+    Pass { build_plan: Option<BuildPlan> },
+}
+
+/// Constructs [`DetectOutcome`] values.
+///
+/// # Examples:
+/// ```
+/// use libcnb::detect::DetectOutcomeBuilder;
+/// use libcnb_data::build_plan::{BuildPlan, BuildPlanBuilder};
+///
+/// let simple_pass = DetectOutcomeBuilder::pass().build();
+/// let simple_fail = DetectOutcomeBuilder::fail().build();
+///
+/// let with_build_plan = DetectOutcomeBuilder::pass()
+///    .build_plan(BuildPlanBuilder::new().provides("something").build())
+///    .build();
+/// ```
+pub struct DetectOutcomeBuilder;
+
+impl DetectOutcomeBuilder {
+    pub fn pass() -> PassDetectOutcomeBuilder {
+        PassDetectOutcomeBuilder { build_plan: None }
+    }
+
+    pub fn fail() -> FailDetectOutcomeBuilder {
+        FailDetectOutcomeBuilder {}
+    }
+}
+
+pub struct PassDetectOutcomeBuilder {
+    build_plan: Option<BuildPlan>,
+}
+
+impl PassDetectOutcomeBuilder {
+    pub fn build(self) -> DetectOutcome {
+        DetectOutcome(InnerDetectOutcome::Pass {
+            build_plan: self.build_plan,
+        })
+    }
+
+    pub fn build_plan(mut self, build_plan: BuildPlan) -> Self {
+        self.build_plan = Some(build_plan);
+        self
+    }
+}
+
+pub struct FailDetectOutcomeBuilder;
+
+impl FailDetectOutcomeBuilder {
+    pub fn build(self) -> DetectOutcome {
+        DetectOutcome(InnerDetectOutcome::Fail)
+    }
 }

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -13,52 +13,52 @@ pub struct DetectContext<B: Buildpack + ?Sized> {
     pub buildpack_descriptor: BuildpackToml<B::Metadata>,
 }
 
-/// Describes the outcome of the detect phase.
+/// Describes the result of the detect phase.
 ///
 /// Besides indicating passing or failing detection, it also contains detect phase output such as
-/// the build plan. To construct values of this type, use a [`DetectOutcomeBuilder`].
+/// the build plan. To construct values of this type, use a [`DetectResultBuilder`].
 #[derive(Debug)]
-pub struct DetectOutcome(pub(crate) InnerDetectOutcome);
+pub struct DetectResult(pub(crate) InnerDetectResult);
 
 #[derive(Debug)]
-pub(crate) enum InnerDetectOutcome {
+pub(crate) enum InnerDetectResult {
     Fail,
     Pass { build_plan: Option<BuildPlan> },
 }
 
-/// Constructs [`DetectOutcome`] values.
+/// Constructs [`DetectResult`] values.
 ///
 /// # Examples:
 /// ```
-/// use libcnb::detect::DetectOutcomeBuilder;
+/// use libcnb::detect::DetectResultBuilder;
 /// use libcnb_data::build_plan::{BuildPlan, BuildPlanBuilder};
 ///
-/// let simple_pass = DetectOutcomeBuilder::pass().build();
-/// let simple_fail = DetectOutcomeBuilder::fail().build();
+/// let simple_pass = DetectResultBuilder::pass().build();
+/// let simple_fail = DetectResultBuilder::fail().build();
 ///
-/// let with_build_plan = DetectOutcomeBuilder::pass()
+/// let with_build_plan = DetectResultBuilder::pass()
 ///    .build_plan(BuildPlanBuilder::new().provides("something").build())
 ///    .build();
 /// ```
-pub struct DetectOutcomeBuilder;
+pub struct DetectResultBuilder;
 
-impl DetectOutcomeBuilder {
-    pub fn pass() -> PassDetectOutcomeBuilder {
-        PassDetectOutcomeBuilder { build_plan: None }
+impl DetectResultBuilder {
+    pub fn pass() -> PassDetectResultBuilder {
+        PassDetectResultBuilder { build_plan: None }
     }
 
-    pub fn fail() -> FailDetectOutcomeBuilder {
-        FailDetectOutcomeBuilder {}
+    pub fn fail() -> FailDetectResultBuilder {
+        FailDetectResultBuilder {}
     }
 }
 
-pub struct PassDetectOutcomeBuilder {
+pub struct PassDetectResultBuilder {
     build_plan: Option<BuildPlan>,
 }
 
-impl PassDetectOutcomeBuilder {
-    pub fn build(self) -> DetectOutcome {
-        DetectOutcome(InnerDetectOutcome::Pass {
+impl PassDetectResultBuilder {
+    pub fn build(self) -> DetectResult {
+        DetectResult(InnerDetectResult::Pass {
             build_plan: self.build_plan,
         })
     }
@@ -69,11 +69,11 @@ impl PassDetectOutcomeBuilder {
     }
 }
 
-pub struct FailDetectOutcomeBuilder;
+pub struct FailDetectResultBuilder;
 
-impl FailDetectOutcomeBuilder {
+impl FailDetectResultBuilder {
     #[allow(clippy::unused_self)]
-    pub fn build(self) -> DetectOutcome {
-        DetectOutcome(InnerDetectOutcome::Fail)
+    pub fn build(self) -> DetectResult {
+        DetectResult(InnerDetectResult::Fail)
     }
 }

--- a/libcnb/src/error.rs
+++ b/libcnb/src/error.rs
@@ -38,6 +38,12 @@ pub enum Error<E: Debug + Display> {
     #[error("Cannot write build plan: {0}")]
     CannotWriteBuildPlan(TomlFileError),
 
+    #[error("Cannot write launch.toml: {0}")]
+    CannotWriteLaunch(TomlFileError),
+
+    #[error("Cannot write store.toml: {0}")]
+    CannotWriteStore(TomlFileError),
+
     #[error("Buildpack error: {0}")]
     BuildpackError(E),
 }

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -33,6 +33,7 @@ pub mod layer_lifecycle;
 
 use crate::data::buildpack::BuildpackApi;
 pub use build::BuildContext;
+pub use build::BuildOutcome;
 pub use buildpack::Buildpack;
 pub use detect::DetectContext;
 pub use detect::DetectOutcome;

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -27,16 +27,14 @@
 // https://github.com/Malax/libcnb.rs/issues/64
 #![allow(clippy::unnecessary_wraps)]
 
+pub mod build;
+pub mod detect;
 pub mod layer_env;
-
 pub mod layer_lifecycle;
 
 use crate::data::buildpack::BuildpackApi;
-pub use build::BuildContext;
-pub use build::BuildOutcome;
 pub use buildpack::Buildpack;
-pub use detect::DetectContext;
-pub use detect::DetectOutcome;
+
 pub use env::*;
 pub use error::*;
 pub use generic::*;
@@ -45,9 +43,7 @@ pub use platform::*;
 pub use runtime::cnb_runtime;
 pub use toml_file::*;
 
-mod build;
 mod buildpack;
-mod detect;
 mod env;
 mod error;
 mod generic;

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -137,7 +137,6 @@ fn cnb_runtime_build<B: Buildpack>(buildpack: &B) -> Result<(), B::Error> {
     })?;
 
     match build_outcome.0 {
-        InnerBuildOutcome::Fail => process::exit(1),
         InnerBuildOutcome::Pass { launch, store } => {
             if let Some(launch) = launch {
                 write_toml_file(&launch, layers_dir.join("launch.toml"))


### PR DESCRIPTION
Previously, writing any additional CNB metadata during/after the build phase required calling functions on `BuildContext` which would write the given CNB data value to disk. This is of course a side-effect and also not declarative.

Since the API of this framework became more and more declarative, writing these metadata files should not be a side-effecting method on `BuildContext`. Instead, this PR introduces `BuildResult` which is very similar to `DetectResult`. It describes the outcome of the build phase and can carry additional metadata which will be transparently handled by libcnb, including any errors that might arise during that process.

As an example, writing `launch.toml` looked like this before (taken from the ruby example):
```rust
let mut launch_toml = data::launch::Launch::new();
let web =
    data::launch::Process::new("web", "bundle", vec!["exec", "ruby", "app.rb"], false, true)?;

let worker = data::launch::Process::new(
    "worker",
    "bundle",
    vec!["exec", "ruby", "worker.rb"],
    false,
    false,
)?;

launch_toml.processes.push(web);
launch_toml.processes.push(worker);

context.write_launch(launch_toml)?;
```

Now, at the end of `build`, launch metadata is returned and will be handled by libcnb.rs:

```rust
Ok(BuildResultBuilder::new()
            .launch(
                Launch::new()
                    .process(Process::new(
                        "web",
                        "bundle",
                        vec!["exec", "ruby", "app.rb"],
                        false,
                        true,
                    )?)
                    .process(Process::new(
                        "worker",
                        "bundle",
                        vec!["exec", "ruby", "worker.rb"],
                        false,
                        false,
                    )?),
            )
            .build())
```

Simplifying the construction of `Launch` values was not in-scope for this PR and will follow separately.

Sadly, we cannot use an enum for `BuildResult` since it's more complex than `DetectResult` which requires providing a builder for it to ensure good DX. I decided to refactor `DetectResult` to match the API of the newly introduced `BuildResult`. This makes the `detect` and `build` functions very similar, reducing amount of API users have to learn. As nice side-effect, this makes passing detect without a build plan much more straightforward: just don't provide one to the builder.