### PR TITLE
Add buildpack_main macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,7 @@
 - `build` now returns `Result<BuildResult, E>` instead of `Result<(), E>`. Construct `BuildResult` values by using the new `BuildResultBuilder`.
 - `detect` now returns `DetectResult` instead of a `DetectOutcome` enum. Construct `DetectResult` values by using the new `DetectResultBuilder`.
 - `BuildContext#write_launch` was removed. Return a `Launch` value from `build` via `BuildResult` instead.
+- `cnb_runtime` was renamed to `libcnb_runtime`.
+- Introduced `buildpack_main` macro to initialize the framework.
 
 ## [0.3.0] 2021/09/17

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A basic hello world buildpack looks like this:
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::{
-    cnb_runtime, data::build_plan::BuildPlan, Buildpack, GenericError, GenericMetadata,
+    buildpack_main, data::build_plan::BuildPlan, Buildpack, GenericError, GenericMetadata,
     GenericPlatform,
 };
 
@@ -82,8 +82,6 @@ impl Buildpack for HelloWorldBuildpack {
     }
 }
 
-fn main() {
-    // This kicks of the framework for the given buildpack.
-    cnb_runtime(HelloWorldBuildpack);
-}
+// Implements the main function and wires up the framework for the given buildpack.
+buildpack_main!(HelloWorldBuildpack);
 ```

--- a/libcnb/examples/example-01-basics/src/main.rs
+++ b/libcnb/examples/example-01-basics/src/main.rs
@@ -1,6 +1,6 @@
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
-use libcnb::{cnb_runtime, Buildpack, GenericError, GenericMetadata, GenericPlatform};
+use libcnb::{buildpack_main, Buildpack, GenericError, GenericMetadata, GenericPlatform};
 
 struct BasicBuildpack;
 impl Buildpack for BasicBuildpack {
@@ -18,6 +18,4 @@ impl Buildpack for BasicBuildpack {
     }
 }
 
-fn main() {
-    cnb_runtime(BasicBuildpack);
-}
+buildpack_main!(BasicBuildpack);

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -8,7 +8,7 @@ use libcnb::data::launch::{Launch, Process};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::layer_lifecycle::execute_layer_lifecycle;
 use libcnb::Buildpack;
-use libcnb::{cnb_runtime, GenericPlatform};
+use libcnb::{buildpack_main, GenericPlatform};
 use serde::Deserialize;
 
 mod layers;
@@ -61,9 +61,7 @@ impl Buildpack for RubyBuildpack {
     }
 }
 
-fn main() {
-    cnb_runtime(RubyBuildpack)
-}
+buildpack_main!(RubyBuildpack);
 
 #[derive(Deserialize, Debug)]
 struct RubyBuildpackMetadata {

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -40,7 +40,7 @@ pub use error::*;
 pub use generic::*;
 pub use libcnb_data as data;
 pub use platform::*;
-pub use runtime::cnb_runtime;
+pub use runtime::libcnb_runtime;
 pub use toml_file::*;
 
 mod buildpack;
@@ -52,6 +52,15 @@ mod runtime;
 mod toml_file;
 
 const LIBCNB_SUPPORTED_BUILDPACK_API: BuildpackApi = BuildpackApi { major: 0, minor: 6 };
+
+#[macro_export]
+macro_rules! buildpack_main {
+    ($buildpack:expr) => {
+        fn main() {
+            ::libcnb::libcnb_runtime($buildpack);
+        }
+    };
+}
 
 // This runs the README.md as a doctest, ensuring the code examples in it are valid.
 // It will not be part of the final crate.

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -25,7 +25,7 @@ use std::fmt::{Debug, Display};
 /// hard links to this single binary.
 ///
 /// Currently symlinks are recommended over hard hard links due to [buildpacks/pack#1286](https://github.com/buildpacks/pack/issues/1286).
-pub fn cnb_runtime<B: Buildpack>(buildpack: B) {
+pub fn libcnb_runtime<B: Buildpack>(buildpack: B) {
     match read_buildpack_toml::<B::Metadata, B::Error>() {
         Ok(buildpack_toml) => {
             if buildpack_toml.api != LIBCNB_SUPPORTED_BUILDPACK_API {
@@ -59,8 +59,8 @@ pub fn cnb_runtime<B: Buildpack>(buildpack: B) {
 
     #[cfg(any(target_family = "unix"))]
     let result = match current_exe_file_name {
-        Some("detect") => cnb_runtime_detect(&buildpack),
-        Some("build") => cnb_runtime_build(&buildpack),
+        Some("detect") => libcnb_runtime_detect(&buildpack),
+        Some("build") => libcnb_runtime_build(&buildpack),
         other => {
             eprintln!(
                 "Error: Expected the name of this executable to be 'detect' or 'build', but it was '{}'",
@@ -78,7 +78,7 @@ pub fn cnb_runtime<B: Buildpack>(buildpack: B) {
     }
 }
 
-fn cnb_runtime_detect<B: Buildpack>(buildpack: &B) -> Result<(), B::Error> {
+fn libcnb_runtime_detect<B: Buildpack>(buildpack: &B) -> Result<(), B::Error> {
     let args = parse_detect_args_or_exit();
 
     let app_dir = env::current_dir().map_err(Error::CannotDetermineAppDirectory)?;
@@ -111,7 +111,7 @@ fn cnb_runtime_detect<B: Buildpack>(buildpack: &B) -> Result<(), B::Error> {
     }
 }
 
-fn cnb_runtime_build<B: Buildpack>(buildpack: &B) -> Result<(), B::Error> {
+fn libcnb_runtime_build<B: Buildpack>(buildpack: &B) -> Result<(), B::Error> {
     let args = parse_build_args_or_exit();
 
     let layers_dir = args.layers_dir_path;


### PR DESCRIPTION
Introduces a macro to reduce some boilerplate to initialise the framework. It will create `fn main` for the user with the appropriate bootstrap code.

Also renames `cnb_runtime` to `libcnb_runtime`.

Before: 
```
fn main() {
    cnb_runtime(HelloWorldBuildpack);
}
```

Now: 
```
buildpack_main!(HelloWorldBuildpack);
```