### PR TITLE
reference method directly

### DIFF
--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -79,7 +79,7 @@ impl Process {
         Ok(Self {
             r#type: ProcessType::from_str(r#type.as_ref())?,
             command: command.into(),
-            args: args.into_iter().map(|i| i.into()).collect(),
+            args: args.into_iter().map(std::convert::Into::into).collect(),
             direct,
             default,
         })

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -20,8 +20,6 @@
 #![allow(clippy::must_use_candidate)]
 // https://github.com/Malax/libcnb.rs/issues/63
 #![allow(clippy::needless_pass_by_value)]
-// https://github.com/Malax/libcnb.rs/issues/61
-#![allow(clippy::redundant_closure_for_method_calls)]
 // https://github.com/Malax/libcnb.rs/issues/64
 #![allow(clippy::unnecessary_wraps)]
 


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_for_method_calls
Fixes #61 