### PR TITLE
Use `ModificationBehavior::Delimiter` instead of a wildcard enum match

### DIFF
--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -429,7 +429,7 @@ impl LayerEnvDelta {
 
                     result_env.insert(&name, new_value);
                 }
-                _ => (),
+                ModificationBehavior::Delimiter => (),
             };
         }
 

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -8,8 +8,6 @@
 // Re-disable pedantic lints that are currently failing, until they are triaged and fixed/wontfixed.
 // https://github.com/Malax/libcnb.rs/issues/60
 #![allow(clippy::doc_markdown)]
-// https://github.com/Malax/libcnb.rs/issues/62
-#![allow(clippy::match_wildcard_for_single_variants)]
 // https://github.com/Malax/libcnb.rs/issues/53
 #![allow(clippy::missing_errors_doc)]
 // https://github.com/Malax/libcnb.rs/issues/54


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#match_wildcard_for_single_variants
Fixes #62 