### PR TITLE
Avoid undocumented panics and enable `clippy::missing-panics-doc`

### DIFF
--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -262,7 +262,7 @@ impl LayerEnv {
                 let target_delta = match target_lifecycle {
                     TargetLifecycle::Build => &mut result_layer_env.layer_paths_build,
                     TargetLifecycle::Launch => &mut result_layer_env.layer_paths_launch,
-                    _ => panic!("Unexpected TargetLifecycle in read_from_layer_dir implementation. This is a libcnb implementation error!"),
+                    _ => unreachable!("Unexpected TargetLifecycle in read_from_layer_dir implementation. This is a libcnb implementation error!"),
                 };
 
                 target_delta.insert(ModificationBehavior::Prepend, &name, &path);

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -10,8 +10,6 @@
 // Re-disable pedantic lints that are currently failing, until they are triaged and fixed/wontfixed.
 // https://github.com/Malax/libcnb.rs/issues/53
 #![allow(clippy::missing_errors_doc)]
-// https://github.com/Malax/libcnb.rs/issues/54
-#![allow(clippy::missing_panics_doc)]
 // https://github.com/Malax/libcnb.rs/issues/57
 #![allow(clippy::must_use_candidate)]
 // https://github.com/Malax/libcnb.rs/issues/63


### PR DESCRIPTION
Switches the `panic!` in `LayerEnv::read_from_layer_dir()` to `unreachable!`, since:
- it more clearly indicates the intent (unreachable code unless there is a bug)
- it means we can globally enable the `clippy::missing-panics-doc` lint, without having to either:
  (a) add an unnecessary `# Panic` section to the docs (which would only add noise, given the caller needn't be aware of panics for internal bugs)
  (b) add an `#[allow(...)]` annotation to all of `read_from_layer_dir()`, which could mean future new undocumented panics aren't caught by clippy.

Fixes #54.