### PR TITLE
Mark `clippy:module_name_repetitions` disablement as permanent

### DIFF
--- a/libcnb-data/src/lib.rs
+++ b/libcnb-data/src/lib.rs
@@ -5,11 +5,11 @@
 #![warn(unused_crate_dependencies)]
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
+// This lint is too noisy and enforces a style that reduces readability in many cases.
+#![allow(clippy::module_name_repetitions)]
 // Re-disable pedantic lints that are currently failing, until they are triaged and fixed/wontfixed.
 // https://github.com/Malax/libcnb.rs/issues/53
 #![allow(clippy::missing_errors_doc)]
-// https://github.com/Malax/libcnb.rs/issues/83
-#![allow(clippy::module_name_repetitions)]
 // https://github.com/Malax/libcnb.rs/issues/57
 #![allow(clippy::must_use_candidate)]
 // https://github.com/Malax/libcnb.rs/issues/61

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -5,6 +5,8 @@
 #![warn(unused_crate_dependencies)]
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
+// This lint is too noisy and enforces a style that reduces readability in many cases.
+#![allow(clippy::module_name_repetitions)]
 // Re-disable pedantic lints that are currently failing, until they are triaged and fixed/wontfixed.
 // https://github.com/Malax/libcnb.rs/issues/60
 #![allow(clippy::doc_markdown)]
@@ -12,8 +14,6 @@
 #![allow(clippy::missing_errors_doc)]
 // https://github.com/Malax/libcnb.rs/issues/54
 #![allow(clippy::missing_panics_doc)]
-// https://github.com/Malax/libcnb.rs/issues/83
-#![allow(clippy::module_name_repetitions)]
 // https://github.com/Malax/libcnb.rs/issues/57
 #![allow(clippy::must_use_candidate)]
 // https://github.com/Malax/libcnb.rs/issues/63


### PR DESCRIPTION
Many of the disabled lints are wanted and just haven't been fixed yet. However, for this lint, it is too noisy and enforces a style that reduces readability in many cases. 

As such, it has been moved out of the "to triage/fix" list to indicate it is a long-term disablement.

Closes #83.