### PR TITLE
Add docs for `Buildpack` and related types

### DIFF
--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -1,3 +1,5 @@
+//! Provides build phase specific types and helpers.
+
 use std::{fs, path::PathBuf};
 
 use serde::de::DeserializeOwned;

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -4,15 +4,45 @@ use crate::Platform;
 use serde::de::DeserializeOwned;
 use std::fmt::{Debug, Display};
 
+/// Represents a buildpack written with the libcnb framework.
+///
+/// To implement a buildpack with this framework, start by implementing this trait. Besides the main
+/// build and detect methods, it also holds associated types for the buildpack: the [`Platform`] it
+/// is targeting, the type for its metadata and the custom error type.
 pub trait Buildpack {
+    /// The platform targeted by this buildpack. If no specific platform is targeted, consider using
+    /// [`GenericPlatform`](crate::GenericPlatform) as the type.
     type Platform: Platform;
+
+    /// The metadata type for this buildpack. This is the data within `[metadata]` of the buildpacks
+    /// `buildpack.toml`. The framework will attempt to parse the data and will only continue if
+    /// parsing succeeded. If you wish to use raw, untyped, TOML data instead, use
+    /// [`GenericMetadata`](crate::GenericMetadata).
     type Metadata: DeserializeOwned;
+
+    /// The error type for buildpack specific errors, usually an enum. Examples of values inside the
+    /// enum are: `MavenExecutionFailed`, `InvalidGemfileLock`, `IncompatiblePythonVersion`. The
+    /// framework itself has its [own error type](crate::error::Error) that contains more low-level errors that can occur
+    /// during buildpack execution.
     type Error: Debug + Display;
 
+    /// Detect logic for this buildpack. Directly corresponds to
+    /// [detect in the CNB buildpack interface](https://github.com/buildpacks/spec/blob/platform/v0.6/buildpack.md#detection).
     fn detect(&self, context: DetectContext<Self>) -> crate::Result<DetectResult, Self::Error>;
 
+    /// Build logic for this buildpack. Directly corresponds to
+    /// [build in the CNB buildpack interface](https://github.com/buildpacks/spec/blob/platform/v0.6/buildpack.md#build).
     fn build(&self, context: BuildContext<Self>) -> crate::Result<BuildResult, Self::Error>;
 
+    /// If an unhandled error occurred within the framework or the buildpack, this method will be
+    /// called by the framework to allow custom, buildpack specific, error handling. Usually,
+    /// this method is implemented by logging the error in a user friendly manner.
+    ///
+    /// Implementations are not limited to just logging, for example, buildpacks might want to
+    /// collect and send metrics about occurring errors to a central system.
+    ///
+    /// The default implementation will simply print the error
+    /// (using its [`Display`] implementation) to stderr.
     fn handle_error(&self, error: crate::Error<Self::Error>) -> i32 {
         eprintln!("Unhandled error:");
         eprintln!("> {}", error);

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -54,6 +54,8 @@ impl DetectResultBuilder {
     }
 }
 
+/// Constructs [`DetectResult`] values for a passed detection. Can't be used directly, use
+/// a [`DetectResultBuilder`] to create an instance.
 pub struct PassDetectResultBuilder {
     build_plan: Option<BuildPlan>,
 }
@@ -71,6 +73,8 @@ impl PassDetectResultBuilder {
     }
 }
 
+/// Constructs [`DetectResult`] values for a failed detection. Can't be used directly, use
+/// a [`DetectResultBuilder`] to create an instance.
 pub struct FailDetectResultBuilder;
 
 impl FailDetectResultBuilder {

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -1,3 +1,5 @@
+//! Provides detect phase specific types and helpers.
+
 use std::fmt::Debug;
 use std::path::PathBuf;
 

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -43,6 +43,37 @@ mod toml_file;
 
 const LIBCNB_SUPPORTED_BUILDPACK_API: BuildpackApi = BuildpackApi { major: 0, minor: 6 };
 
+/// Generates a main function for the given buildpack.
+///
+/// It will create the main function and wires up the buildpack to the framework.
+///
+/// # Example:
+/// ```
+/// use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+/// use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
+/// use libcnb::{
+///     buildpack_main, data::build_plan::BuildPlan, Buildpack, GenericError, GenericMetadata,
+///     GenericPlatform,
+/// };
+///
+/// struct MyBuildpack;
+///
+/// impl Buildpack for MyBuildpack {
+///     type Platform = GenericPlatform;
+///     type Metadata = GenericMetadata;
+///     type Error = GenericError;
+///
+///     fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+///         Ok(DetectResultBuilder::pass().build())
+///     }
+///
+///     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+///         Ok(BuildResultBuilder::new().build())
+///     }
+/// }
+///
+/// buildpack_main!(MyBuildpack);
+/// ```
 #[macro_export]
 macro_rules! buildpack_main {
     ($buildpack:expr) => {

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -25,6 +25,9 @@ use std::fmt::{Debug, Display};
 /// hard links to this single binary.
 ///
 /// Currently symlinks are recommended over hard hard links due to [buildpacks/pack#1286](https://github.com/buildpacks/pack/issues/1286).
+///
+/// Don't implement this directly and use the [`buildpack_main`] macro instead!
+#[doc(hidden)]
 pub fn libcnb_runtime<B: Buildpack>(buildpack: B) {
     match read_buildpack_toml::<B::Metadata, B::Error>() {
         Ok(buildpack_toml) => {


### PR DESCRIPTION
Follow-up for #129 - adds Rustdoc for newly introduced types, macros and modules. 