### PR TITLE
Ruby example cleanup and fixes

### DIFF
--- a/libcnb/examples/example-02-ruby-sample/buildpack.toml
+++ b/libcnb/examples/example-02-ruby-sample/buildpack.toml
@@ -1,5 +1,5 @@
 # Buildpack API version
-api = "0.5"
+api = "0.6"
 
 # Buildpack ID and metadata
 [buildpack]
@@ -9,10 +9,7 @@ name = "Ruby Buildpack"
 
 # Stacks that the buildpack will work with
 [[stacks]]
-id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-id = "heroku-18"
+id = "heroku-20"
 
 [metadata]
-ruby_url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.5.1.tgz"
+ruby_url = "https://heroku-buildpack-ruby.s3.amazonaws.com/heroku-20/ruby-2.7.4.tgz"

--- a/libcnb/examples/example-02-ruby-sample/src/layers/bundler.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/bundler.rs
@@ -12,13 +12,13 @@ use sha2::Digest;
 use crate::RubyBuildpack;
 use libcnb::build::BuildContext;
 
-pub struct BundlerLayerLifecycle {
-    pub ruby_env: HashMap<String, String>,
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct BundlerLayerMetadata {
+    gemfile_lock_checksum: String,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
-pub struct BundlerLayerMetadata {
-    checksum: String,
+pub struct BundlerLayerLifecycle {
+    pub ruby_env: HashMap<String, String>,
 }
 
 impl LayerLifecycle<RubyBuildpack, BundlerLayerMetadata, HashMap<String, String>>
@@ -29,9 +29,21 @@ impl LayerLifecycle<RubyBuildpack, BundlerLayerMetadata, HashMap<String, String>
         layer_path: &Path,
         build_context: &BuildContext<RubyBuildpack>,
     ) -> anyhow::Result<LayerContentMetadata<BundlerLayerMetadata>> {
+        println!("---> Installing bundler");
+
+        let install_bundler_exit_code = Command::new("gem")
+            .args(&["install", "bundler", "--no-ri", "--no-rdoc"])
+            .envs(&self.ruby_env)
+            .spawn()?
+            .wait()?;
+
+        if !install_bundler_exit_code.success() {
+            return Err(anyhow::anyhow!("Could not install bundler!"));
+        }
+
         println!("---> Installing gems");
 
-        let cmd = Command::new("bundle")
+        let bundle_exit_code = Command::new("bundle")
             .args(&[
                 "install",
                 "--path",
@@ -42,15 +54,16 @@ impl LayerLifecycle<RubyBuildpack, BundlerLayerMetadata, HashMap<String, String>
             .envs(&self.ruby_env)
             .spawn()?
             .wait()?;
-        if !cmd.success() {
-            anyhow::anyhow!("Could not bundle install");
+
+        if !bundle_exit_code.success() {
+            return Err(anyhow::anyhow!("Could not install gems!"));
         }
 
         Ok(LayerContentMetadata::default()
             .launch(true)
             .cache(true)
             .metadata(BundlerLayerMetadata {
-                checksum: sha256_checksum(build_context.app_dir.join("Gemfile.lock"))?,
+                gemfile_lock_checksum: sha256_checksum(build_context.app_dir.join("Gemfile.lock"))?,
             }))
     }
 
@@ -61,7 +74,9 @@ impl LayerLifecycle<RubyBuildpack, BundlerLayerMetadata, HashMap<String, String>
         build_context: &BuildContext<RubyBuildpack>,
     ) -> ValidateResult {
         let checksum_matches = sha256_checksum(build_context.app_dir.join("Gemfile.lock"))
-            .map(|local_checksum| local_checksum == layer_content_metadata.metadata.checksum)
+            .map(|local_checksum| {
+                local_checksum == layer_content_metadata.metadata.gemfile_lock_checksum
+            })
             .unwrap_or(false);
 
         if checksum_matches {
@@ -78,6 +93,7 @@ impl LayerLifecycle<RubyBuildpack, BundlerLayerMetadata, HashMap<String, String>
         _build_context: &BuildContext<RubyBuildpack>,
     ) -> anyhow::Result<LayerContentMetadata<BundlerLayerMetadata>> {
         println!("---> Reusing gems");
+
         Command::new("bundle")
             .args(&["config", "--local", "path", layer_path.to_str().unwrap()])
             .envs(&self.ruby_env)

--- a/libcnb/examples/example-02-ruby-sample/src/layers/mod.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/mod.rs
@@ -1,2 +1,5 @@
-pub mod bundler;
-pub mod ruby;
+mod bundler;
+mod ruby;
+
+pub use bundler::*;
+pub use ruby::*;

--- a/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
@@ -25,7 +25,10 @@ impl LayerLifecycle<RubyBuildpack, GenericMetadata, HashMap<String, String>>
         layer_path: &Path,
         build_context: &BuildContext<RubyBuildpack>,
     ) -> anyhow::Result<LayerContentMetadata<GenericMetadata>> {
+        println!("---> Download and extracting Ruby");
+
         let ruby_tgz = NamedTempFile::new()?;
+
         download(
             &build_context.buildpack_descriptor.metadata.ruby_url,
             ruby_tgz.path(),


### PR DESCRIPTION
* Updates the `buildpack.toml` buildpack API version to match that supported by libcnb.
* Switches from `heroku-18` to `heroku-20` stack (ideally would support both, but out of scope for now).
* Upgrades to a supported Ruby version.
* Stops using the legacy S3 URL form.
* Moves the installing bundler step into the bundler layer.
* Fixes the missing `return Err()` for the bundle install `anyhow!` usage.
* Misc other whitespace/reordering changes from #144 to reduce the diff there.

Most of these were split out of #144 in order to make that PR easier to review and so reviewers and future buildpack maintainers can more easily see how the typical usage of the libcnb API has changed by looking at the edits to the examples in that PR.