### PR TITLE
Move generic implementations into module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,6 @@
 - `cnb_runtime` was renamed to `libcnb_runtime`.
 - Introduced `buildpack_main` macro to initialize the framework.
 - Switch to BSD 3-Clause License.
+- `Generic*` implementations moved to the `generic` module.
 
 ## [0.3.0] 2021/09/17

--- a/README.md
+++ b/README.md
@@ -37,10 +37,8 @@ A basic hello world buildpack looks like this:
 ```rust,no_run
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
-use libcnb::{
-    buildpack_main, data::build_plan::BuildPlan, Buildpack, GenericError, GenericMetadata,
-    GenericPlatform,
-};
+use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
+use libcnb::{buildpack_main, data::build_plan::BuildPlan, Buildpack};
 
 struct HelloWorldBuildpack;
 

--- a/libcnb/examples/example-01-basics/src/main.rs
+++ b/libcnb/examples/example-01-basics/src/main.rs
@@ -1,6 +1,7 @@
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
-use libcnb::{buildpack_main, Buildpack, GenericError, GenericMetadata, GenericPlatform};
+use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
+use libcnb::{buildpack_main, Buildpack};
 
 struct BasicBuildpack;
 impl Buildpack for BasicBuildpack {

--- a/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/layers/ruby.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 use flate2::read::GzDecoder;
 use libcnb::data::layer_content_metadata::LayerContentMetadata;
 use libcnb::layer_lifecycle::LayerLifecycle;
-use libcnb::GenericMetadata;
 
 use std::env;
 use tar::Archive;
@@ -14,6 +13,7 @@ use tempfile::NamedTempFile;
 
 use crate::RubyBuildpack;
 use libcnb::build::BuildContext;
+use libcnb::generic::GenericMetadata;
 
 pub struct RubyLayerLifecycle;
 

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -1,11 +1,12 @@
 use crate::layers::BundlerLayerLifecycle;
 use crate::layers::RubyLayerLifecycle;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+use libcnb::buildpack_main;
 use libcnb::data::launch::{Launch, Process};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
+use libcnb::generic::GenericPlatform;
 use libcnb::layer_lifecycle::execute_layer_lifecycle;
 use libcnb::Buildpack;
-use libcnb::{buildpack_main, GenericPlatform};
 use serde::Deserialize;
 
 mod layers;

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -11,13 +11,13 @@ use std::fmt::{Debug, Display};
 /// is targeting, the type for its metadata and the custom error type.
 pub trait Buildpack {
     /// The platform targeted by this buildpack. If no specific platform is targeted, consider using
-    /// [`GenericPlatform`](crate::GenericPlatform) as the type.
+    /// [`GenericPlatform`](crate::generic::GenericPlatform) as the type.
     type Platform: Platform;
 
     /// The metadata type for this buildpack. This is the data within `[metadata]` of the buildpacks
     /// `buildpack.toml`. The framework will attempt to parse the data and will only continue if
     /// parsing succeeded. If you wish to use raw, untyped, TOML data instead, use
-    /// [`GenericMetadata`](crate::GenericMetadata).
+    /// [`GenericMetadata`](crate::generic::GenericMetadata).
     type Metadata: DeserializeOwned;
 
     /// The error type for buildpack specific errors, usually an enum. Examples of values inside the

--- a/libcnb/src/generic.rs
+++ b/libcnb/src/generic.rs
@@ -1,3 +1,5 @@
+//! Generic implementations for some libcnb types.
+
 use std::path::Path;
 
 use crate::platform::{Platform, PlatformEnv};

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -19,13 +19,13 @@
 
 pub mod build;
 pub mod detect;
+pub mod generic;
 pub mod layer_env;
 pub mod layer_lifecycle;
 
 mod buildpack;
 mod env;
 mod error;
-mod generic;
 mod platform;
 mod runtime;
 mod toml_file;
@@ -35,7 +35,6 @@ pub use libcnb_data as data;
 
 pub use env::*;
 pub use error::*;
-pub use generic::*;
 pub use platform::*;
 pub use toml_file::*;
 
@@ -53,10 +52,8 @@ const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =
 /// ```
 /// use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 /// use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
-/// use libcnb::{
-///     buildpack_main, data::build_plan::BuildPlan, Buildpack, GenericError, GenericMetadata,
-///     GenericPlatform,
-/// };
+/// use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
+/// use libcnb::{buildpack_main, data::build_plan::BuildPlan, Buildpack};
 ///
 /// struct MyBuildpack;
 ///

--- a/libcnb/src/platform.rs
+++ b/libcnb/src/platform.rs
@@ -26,7 +26,7 @@ where
     /// # Examples
     /// ```no_run
     ///use libcnb::Platform;
-    ///use libcnb::GenericPlatform;
+    ///use libcnb::generic::GenericPlatform;
     ///let platform = GenericPlatform::from_path("/platform").unwrap();
     /// ```
     fn from_path(platform_dir: impl AsRef<Path>) -> io::Result<Self>;


### PR DESCRIPTION
Previously, `Generic*` implementations were exported at the root of the `libcnb` crate. This PR moves them back to their own module to reduce clutter in the main namespace.