### PR TITLE
Remove PlatformEnv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,5 +21,6 @@
 - Switch to BSD 3-Clause License.
 - `Generic*` implementations moved to the `generic` module.
 - `LayerContentTypeTable` has been renamed to `LayerTypes`.
+- Remove `PlatformEnv` and replaced it with the already existing `Env`.
 
 ## [0.3.0] 2021/09/17

--- a/libcnb/src/generic.rs
+++ b/libcnb/src/generic.rs
@@ -2,7 +2,8 @@
 
 use std::path::Path;
 
-use crate::platform::{Platform, PlatformEnv};
+use crate::platform::Platform;
+use crate::{read_platform_env, Env};
 use std::fmt::{Debug, Display, Formatter};
 
 /// Generic TOML metadata.
@@ -22,17 +23,21 @@ impl Display for GenericError {
 
 /// A generic platform that only provides access to environment variables.
 pub struct GenericPlatform {
-    env: PlatformEnv,
+    env: Env,
+}
+
+impl GenericPlatform {
+    pub fn new(env: Env) -> Self {
+        Self { env }
+    }
 }
 
 impl Platform for GenericPlatform {
-    fn env(&self) -> &PlatformEnv {
+    fn env(&self) -> &Env {
         &self.env
     }
 
     fn from_path(platform_dir: impl AsRef<Path>) -> std::io::Result<Self> {
-        Ok(Self {
-            env: PlatformEnv::from_path(platform_dir)?,
-        })
+        read_platform_env(platform_dir.as_ref()).map(|env| GenericPlatform { env })
     }
 }

--- a/libcnb/src/platform.rs
+++ b/libcnb/src/platform.rs
@@ -29,6 +29,7 @@ where
     fn from_path(platform_dir: impl AsRef<Path>) -> io::Result<Self>;
 }
 
+/// Initializes a new `Env` based on the given platform directory.
 pub(crate) fn read_platform_env(platform_dir: impl AsRef<Path>) -> std::io::Result<Env> {
     let env_path = platform_dir.as_ref().join("env");
     let mut env_vars = Env::new();

--- a/libcnb/src/platform.rs
+++ b/libcnb/src/platform.rs
@@ -64,7 +64,22 @@ pub(crate) fn read_platform_env(platform_dir: impl AsRef<Path>) -> std::io::Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::fs;
+
+    #[test]
+    fn read_platform_env_reads_correct_env_vars() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let env_dir = tmpdir.path().join("env");
+        fs::create_dir(&env_dir).unwrap();
+
+        fs::write(env_dir.join("FOO"), "BAR").unwrap();
+        fs::write(env_dir.join("HELLO"), "World!").unwrap();
+
+        let env = read_platform_env(tmpdir.path()).unwrap();
+        assert_eq!(env.get("FOO"), Some(OsString::from("BAR")));
+        assert_eq!(env.get("HELLO"), Some(OsString::from("World!")));
+    }
 
     #[test]
     fn read_platform_env_handles_directories_in_env_folder() {

--- a/libcnb/src/platform.rs
+++ b/libcnb/src/platform.rs
@@ -1,10 +1,7 @@
-use std::{
-    collections::HashMap,
-    env::VarError,
-    ffi::{OsStr, OsString},
-    fs, io,
-    path::Path,
-};
+use crate::Env;
+use std::fs;
+use std::io;
+use std::path::Path;
 
 /// Represents a Cloud Native Buildpack platform.
 ///
@@ -17,9 +14,9 @@ pub trait Platform
 where
     Self: Sized,
 {
-    /// Retrieve a [`PlatformEnv`] reference for convenient access to environment variables which
+    /// Retrieve a [`Env`] reference for convenient access to environment variables which
     /// all platforms have to provide.
-    fn env(&self) -> &PlatformEnv;
+    fn env(&self) -> &Env;
 
     /// Initializes the platform from the given platform directory.
     ///
@@ -32,67 +29,35 @@ where
     fn from_path(platform_dir: impl AsRef<Path>) -> io::Result<Self>;
 }
 
-/// Provides access to platform environment variables.
-pub struct PlatformEnv {
-    vars: HashMap<OsString, String>,
-}
+pub(crate) fn read_platform_env(platform_dir: impl AsRef<Path>) -> std::io::Result<Env> {
+    let env_path = platform_dir.as_ref().join("env");
+    let mut env_vars = Env::new();
 
-impl PlatformEnv {
-    /// Fetches the environment variable `key` from the platform.
-    ///
-    /// # Examples
-    /// ```no_run
-    ///use libcnb::PlatformEnv;
-    ///let env = PlatformEnv::from_path("/platform").unwrap();
-    ///let value = env.var("SOME_ENV_VAR");
-    /// ```
-    pub fn var<K: AsRef<OsStr>>(&self, key: K) -> Result<String, VarError> {
-        self.vars
-            .get(key.as_ref())
-            .cloned()
-            .ok_or(VarError::NotPresent)
-    }
+    match fs::read_dir(env_path) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = entry?;
+                let path = entry.path();
 
-    /// Initializes a new `PlatformEnv` from the given platform directory.
-    ///
-    /// Buildpack authors usually do not need to create their own [`PlatformEnv`] and instead use the
-    /// one passed via context structs ([`DetectContext`](crate::detect::DetectContext) and [`BuildContext`](crate::build::BuildContext)).
-    ///
-    /// # Examples
-    /// ```no_run
-    ///use libcnb::PlatformEnv;
-    ///let platform = PlatformEnv::from_path("/platform").unwrap();
-    /// ```
-    pub fn from_path(platform_dir: impl AsRef<Path>) -> Result<Self, io::Error> {
-        let env_path = platform_dir.as_ref().join("env");
-        let mut env_vars: HashMap<OsString, String> = HashMap::new();
-
-        match fs::read_dir(env_path) {
-            Ok(entries) => {
-                for entry in entries {
-                    let entry = entry?;
-                    let path = entry.path();
-
-                    if let Some(file_name) = path.file_name() {
-                        // k8s volume mounts will mount a directory symlink in, so we need to check
-                        // that it's actually a file
-                        if path.is_file() {
-                            let file_contents = fs::read_to_string(&path)?;
-                            env_vars.insert(file_name.to_owned(), file_contents);
-                        }
+                if let Some(file_name) = path.file_name() {
+                    // k8s volume mounts will mount a directory symlink in, so we need to check
+                    // that it's actually a file
+                    if path.is_file() {
+                        let file_contents = fs::read_to_string(&path)?;
+                        env_vars.insert(file_name.to_owned(), file_contents);
                     }
                 }
             }
-            Err(err) => {
-                // don't fail if `<platform>/env` doesn't exist
-                if err.kind() != std::io::ErrorKind::NotFound {
-                    return Err(err);
-                }
+        }
+        Err(err) => {
+            // don't fail if `<platform>/env` doesn't exist
+            if err.kind() != std::io::ErrorKind::NotFound {
+                return Err(err);
             }
         }
-
-        Ok(Self { vars: env_vars })
     }
+
+    Ok(env_vars)
 }
 
 #[cfg(test)]
@@ -101,7 +66,7 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn from_path_handles_directories_in_env_folder() {
+    fn read_platform_env_handles_directories_in_env_folder() {
         let tmpdir = tempfile::tempdir().unwrap();
         let env_dir = tmpdir.path().join("env");
         fs::create_dir(&env_dir).unwrap();
@@ -109,14 +74,14 @@ mod tests {
         fs::create_dir(&dummy_dir).unwrap();
         fs::write(env_dir.join("FOO"), "BAR").unwrap();
 
-        let result = PlatformEnv::from_path(tmpdir.path());
+        let result = read_platform_env(tmpdir.path());
         assert!(result.is_ok());
     }
 
     // this symlink is only supported on unix
     #[cfg(target_family = "unix")]
     #[test]
-    fn from_path_handles_directories_via_symlinks() {
+    fn read_platform_env_handles_directories_via_symlinks() {
         let tmpdir = tempfile::tempdir().unwrap();
         let env_dir = tmpdir.path().join("env");
         fs::create_dir(&env_dir).unwrap();
@@ -126,15 +91,15 @@ mod tests {
         std::os::unix::fs::symlink(&dummy_dir, &dst_symlink).unwrap();
         fs::write(env_dir.join("FOO"), "BAR").unwrap();
 
-        let result = PlatformEnv::from_path(tmpdir.path());
+        let result = read_platform_env(tmpdir.path());
         assert!(result.is_ok());
     }
 
     #[test]
-    fn from_path_doesnt_blow_up_if_platform_env_is_missing() {
+    fn read_platform_env_doesnt_blow_up_if_platform_env_is_missing() {
         let tmpdir = tempfile::tempdir().unwrap();
 
-        let result = PlatformEnv::from_path(tmpdir.path());
+        let result = read_platform_env(tmpdir.path());
         assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
#30 introduced the `Env` type. It was required to have a base environment type where layer environment deltas could be applied to. `PlatformEnv` overlaps with that type almost perfectly. Thus, this PR is removing `PlatformEnv` in favour of `Env`. Besides removing API surface area, this also improves interop between `Platform` and `LayerEnv` since they now use the same type.

