### PR TITLE
Remove redundant serde custom `default` attributes

### DIFF
--- a/libcnb-data/src/buildpack.rs
+++ b/libcnb-data/src/buildpack.rs
@@ -1,4 +1,3 @@
-use crate::defaults;
 use lazy_static::lazy_static;
 use regex::Regex;
 use semver::Version;
@@ -59,7 +58,7 @@ pub struct Buildpack {
     pub version: Version,
     pub homepage: Option<String>,
     #[serde(rename = "clear-env")]
-    #[serde(default = "defaults::r#false")]
+    #[serde(default)]
     pub clear_env: bool,
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -115,7 +114,7 @@ pub struct Order {
 pub struct Group {
     pub id: BuildpackId,
     pub version: Version,
-    #[serde(default = "defaults::r#false")]
+    #[serde(default)]
     pub optional: bool,
 }
 

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -1,5 +1,4 @@
 use crate::bom;
-use crate::defaults;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -64,7 +63,7 @@ pub struct Process {
     pub command: String,
     pub args: Vec<String>,
     pub direct: bool,
-    #[serde(default = "defaults::r#false")]
+    #[serde(default)]
     pub default: bool,
 }
 

--- a/libcnb-data/src/layer_content_metadata.rs
+++ b/libcnb-data/src/layer_content_metadata.rs
@@ -1,21 +1,19 @@
 use serde::{Deserialize, Serialize};
 
-use crate::defaults;
-
 /// Used to specify layer availability based
 /// on buildpack phase.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LayerTypes {
     /// Whether the layer is intended for launch.
-    #[serde(default = "defaults::r#false")]
+    #[serde(default)]
     pub launch: bool,
 
     /// Whether the layer is intended for build.
-    #[serde(default = "defaults::r#false")]
+    #[serde(default)]
     pub build: bool,
 
     /// Whether the layer is cached.
-    #[serde(default = "defaults::r#false")]
+    #[serde(default)]
     pub cache: bool,
 }
 


### PR DESCRIPTION
By default serde's `default` attribute will use `std::default::Default`, meaning that for `bool`s specifying `default = "defaults::r#false"` is redundant:
https://serde.rs/attr-default.html

GUS-W-10178196.