### PR TITLE
Introduce libcnb_newtype macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,6 @@
 - `Generic*` implementations moved to the `generic` module.
 - `LayerContentTypeTable` has been renamed to `LayerTypes`.
 - Remove `PlatformEnv` and replaced it with the already existing `Env`.
+- `StackId`, `ProcessType` and `BuildpackId` now implement `Deref<Target = String>`, `Borrow<String>`, `AsRef<String>` and `Display`.
 
 ## [0.3.0] 2021/09/17

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -12,6 +12,7 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
+lazy_static = "^1.4.0"
 regex = "^1.5.4"
 semver = { version = "^1.0.4", features = ["serde"] }
 serde = { version = "^1.0.126", features = ["derive"] }

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -12,7 +12,6 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
-lazy_static = "^1.4.0"
 regex = "^1.5.4"
 semver = { version = "^1.0.4", features = ["serde"] }
 serde = { version = "^1.0.126", features = ["derive"] }

--- a/libcnb-data/src/buildpack.rs
+++ b/libcnb-data/src/buildpack.rs
@@ -7,55 +7,6 @@ use std::fmt::{Display, Formatter};
 use std::{fmt, str::FromStr};
 use thiserror;
 
-libcnb_newtype!(
-    /// buildpack.toml Buildpack Id. This is a newtype wrapper around a String.
-    /// It MUST only contain numbers, letters, and the characters ., /, and -.
-    /// It also cannot be `config` or `app`.
-    /// Use [`std::str::FromStr`] to create a new instance of this struct.
-    ///
-    /// # Examples
-    /// ```
-    /// use std::str::FromStr;
-    /// use libcnb_data::buildpack::BuildpackId;
-    ///
-    /// let valid = BuildpackId::from_str("heroku/ruby-engine.MRI3");
-    /// assert_eq!(valid.unwrap().as_str(), "heroku/ruby-engine.MRI3");
-    ///
-    /// let invalid = BuildpackId::from_str("!nvalid");
-    /// assert!(invalid.is_err());
-    /// ```
-    BuildpackId,
-    BuildpackIdError,
-    r"^[[:alnum:]./-]+$",
-    |id| { id != "app" && id != "config" }
-);
-
-libcnb_newtype!(
-    /// buildpack.toml Stack Id. This is a newtype wrapper around a String.
-    /// It MUST only contain numbers, letters, and the characters ., /, and -.
-    /// or be `*`.
-    ///
-    /// Use [`std::str::FromStr`] to create a new instance of this struct.
-    ///
-    /// # Examples
-    /// ```
-    /// use std::str::FromStr;
-    /// use libcnb_data::buildpack::StackId;
-    ///
-    /// let valid = StackId::from_str("io.buildpacks.bionic/Latest-2020");
-    /// assert_eq!(valid.unwrap().as_str(), "io.buildpacks.bionic/Latest-2020");
-    ///
-    /// let invalid = StackId::from_str("!nvalid");
-    /// assert!(invalid.is_err());
-    ///
-    /// let invalid = StackId::from_str("*");
-    /// assert!(invalid.is_ok());
-    /// ```
-    StackId,
-    StackIdError,
-    r"^([[:alnum:]./-]+|\*)$"
-);
-
 /// Data structure for the Buildpack descriptor (buildpack.toml).
 ///
 /// # Examples
@@ -222,6 +173,55 @@ impl Display for BuildpackApi {
         formatter.write_str(&format!("{}.{}", self.major, self.minor))
     }
 }
+
+libcnb_newtype!(
+    /// buildpack.toml Buildpack Id. This is a newtype wrapper around a String.
+    /// It MUST only contain numbers, letters, and the characters ., /, and -.
+    /// It also cannot be `config` or `app`.
+    /// Use [`std::str::FromStr`] to create a new instance of this struct.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use libcnb_data::buildpack::BuildpackId;
+    ///
+    /// let valid = BuildpackId::from_str("heroku/ruby-engine.MRI3");
+    /// assert_eq!(valid.unwrap().as_str(), "heroku/ruby-engine.MRI3");
+    ///
+    /// let invalid = BuildpackId::from_str("!nvalid");
+    /// assert!(invalid.is_err());
+    /// ```
+    BuildpackId,
+    BuildpackIdError,
+    r"^[[:alnum:]./-]+$",
+    |id| { id != "app" && id != "config" }
+);
+
+libcnb_newtype!(
+    /// buildpack.toml Stack Id. This is a newtype wrapper around a String.
+    /// It MUST only contain numbers, letters, and the characters ., /, and -.
+    /// or be `*`.
+    ///
+    /// Use [`std::str::FromStr`] to create a new instance of this struct.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use libcnb_data::buildpack::StackId;
+    ///
+    /// let valid = StackId::from_str("io.buildpacks.bionic/Latest-2020");
+    /// assert_eq!(valid.unwrap().as_str(), "io.buildpacks.bionic/Latest-2020");
+    ///
+    /// let invalid = StackId::from_str("!nvalid");
+    /// assert!(invalid.is_err());
+    ///
+    /// let invalid = StackId::from_str("*");
+    /// assert!(invalid.is_ok());
+    /// ```
+    StackId,
+    StackIdError,
+    r"^([[:alnum:]./-]+|\*)$"
+);
 
 #[derive(thiserror::Error, Debug)]
 pub enum BuildpackTomlError {

--- a/libcnb-data/src/buildpack.rs
+++ b/libcnb-data/src/buildpack.rs
@@ -7,11 +7,54 @@ use std::fmt::{Display, Formatter};
 use std::{fmt, str::FromStr};
 use thiserror;
 
-libcnb_newtype!(BuildpackId, BuildpackIdError, r"^[[:alnum:]./-]+$", |id| {
-    id != "app" && id != "config"
-});
+libcnb_newtype!(
+    /// buildpack.toml Buildpack Id. This is a newtype wrapper around a String.
+    /// It MUST only contain numbers, letters, and the characters ., /, and -.
+    /// It also cannot be `config` or `app`.
+    /// Use [`std::str::FromStr`] to create a new instance of this struct.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use libcnb_data::buildpack::BuildpackId;
+    ///
+    /// let valid = BuildpackId::from_str("heroku/ruby-engine.MRI3");
+    /// assert_eq!(valid.unwrap().as_str(), "heroku/ruby-engine.MRI3");
+    ///
+    /// let invalid = BuildpackId::from_str("!nvalid");
+    /// assert!(invalid.is_err());
+    /// ```
+    BuildpackId,
+    BuildpackIdError,
+    r"^[[:alnum:]./-]+$",
+    |id| { id != "app" && id != "config" }
+);
 
-libcnb_newtype!(StackId, StackIdError, r"^([[:alnum:]./-]+|\*)$");
+libcnb_newtype!(
+    /// buildpack.toml Stack Id. This is a newtype wrapper around a String.
+    /// It MUST only contain numbers, letters, and the characters ., /, and -.
+    /// or be `*`.
+    ///
+    /// Use [`std::str::FromStr`] to create a new instance of this struct.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use libcnb_data::buildpack::StackId;
+    ///
+    /// let valid = StackId::from_str("io.buildpacks.bionic/Latest-2020");
+    /// assert_eq!(valid.unwrap().as_str(), "io.buildpacks.bionic/Latest-2020");
+    ///
+    /// let invalid = StackId::from_str("!nvalid");
+    /// assert!(invalid.is_err());
+    ///
+    /// let invalid = StackId::from_str("*");
+    /// assert!(invalid.is_ok());
+    /// ```
+    StackId,
+    StackIdError,
+    r"^([[:alnum:]./-]+|\*)$"
+);
 
 /// Data structure for the Buildpack descriptor (buildpack.toml).
 ///

--- a/libcnb-data/src/buildpack.rs
+++ b/libcnb-data/src/buildpack.rs
@@ -1,4 +1,5 @@
 use crate::newtypes::libcnb_newtype;
+use lazy_static::lazy_static;
 use regex::Regex;
 use semver::Version;
 use serde::Deserialize;
@@ -142,9 +143,11 @@ impl FromStr for BuildpackApi {
     type Err = BuildpackTomlError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let regex = Regex::new(r"^(?P<major>\d+)(\.(?P<minor>\d+))?$").unwrap();
+        lazy_static! {
+            static ref RE: Regex = Regex::new(r"^(?P<major>\d+)(\.(?P<minor>\d+))?$").unwrap();
+        }
 
-        if let Some(captures) = regex.captures(value) {
+        if let Some(captures) = RE.captures(value) {
             if let Some(major) = captures.name("major") {
                 // these should never panic since we check with the regex unless it's greater than
                 // `std::u32::MAX`

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -3,25 +3,6 @@ use crate::newtypes::libcnb_newtype;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-libcnb_newtype!(
-    /// launch.toml Process Type. This is a newtype wrapper around a String. It MUST only contain numbers, letters, and the characters ., _, and -. Use [`std::str::FromStr`] to create a new instance of this struct.
-    ///
-    /// # Examples
-    /// ```
-    /// use std::str::FromStr;
-    /// use libcnb_data::launch::ProcessType;
-    ///
-    /// let valid = ProcessType::from_str("foo-Bar_9");
-    /// assert_eq!(valid.unwrap().as_str(), "foo-Bar_9");
-    ///
-    /// let invalid = ProcessType::from_str("!nv4lid");
-    /// assert!(invalid.is_err());
-    /// ```
-    ProcessType,
-    ProcessTypeError,
-    r"^[[:alnum:]\._-]+$"
-);
-
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Launch {
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -106,6 +87,25 @@ impl Process {
 pub struct Slice {
     pub paths: Vec<String>,
 }
+
+libcnb_newtype!(
+    /// launch.toml Process Type. This is a newtype wrapper around a String. It MUST only contain numbers, letters, and the characters ., _, and -. Use [`std::str::FromStr`] to create a new instance of this struct.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use libcnb_data::launch::ProcessType;
+    ///
+    /// let valid = ProcessType::from_str("foo-Bar_9");
+    /// assert_eq!(valid.unwrap().as_str(), "foo-Bar_9");
+    ///
+    /// let invalid = ProcessType::from_str("!nv4lid");
+    /// assert!(invalid.is_err());
+    /// ```
+    ProcessType,
+    ProcessTypeError,
+    r"^[[:alnum:]\._-]+$"
+);
 
 #[cfg(test)]
 mod tests {

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -3,7 +3,24 @@ use crate::newtypes::libcnb_newtype;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-libcnb_newtype!(ProcessType, ProcessTypeError, r"^[[:alnum:]\._-]+$");
+libcnb_newtype!(
+    /// launch.toml Process Type. This is a newtype wrapper around a String. It MUST only contain numbers, letters, and the characters ., _, and -. Use [`std::str::FromStr`] to create a new instance of this struct.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::FromStr;
+    /// use libcnb_data::launch::ProcessType;
+    ///
+    /// let valid = ProcessType::from_str("foo-Bar_9");
+    /// assert_eq!(valid.unwrap().as_str(), "foo-Bar_9");
+    ///
+    /// let invalid = ProcessType::from_str("!nv4lid");
+    /// assert!(invalid.is_err());
+    /// ```
+    ProcessType,
+    ProcessTypeError,
+    r"^[[:alnum:]\._-]+$"
+);
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Launch {

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -1,9 +1,9 @@
 use crate::bom;
-use lazy_static::lazy_static;
-use regex::Regex;
+use crate::newtypes::libcnb_newtype;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use thiserror;
+
+libcnb_newtype!(ProcessType, ProcessTypeError, r"^[[:alnum:]\._-]+$");
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Launch {
@@ -88,53 +88,6 @@ impl Process {
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Slice {
     pub paths: Vec<String>,
-}
-
-/// launch.toml Process Type. This is a newtype wrapper around a String. It MUST only contain numbers, letters, and the characters ., _, and -. Use [`std::str::FromStr`] to create a new instance of this struct.
-///
-/// # Examples
-/// ```
-/// use std::str::FromStr;
-/// use libcnb_data::launch::ProcessType;
-///
-/// let valid = ProcessType::from_str("foo-Bar_9");
-/// assert_eq!(valid.unwrap().as_str(), "foo-Bar_9");
-///
-/// let invalid = ProcessType::from_str("!nv4lid");
-/// assert!(invalid.is_err());
-/// ```
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
-pub struct ProcessType(String);
-
-impl ProcessType {
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl FromStr for ProcessType {
-    type Err = ProcessTypeError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        lazy_static! {
-            static ref RE: Regex = Regex::new(r"^[[:alnum:]\._-]+$").unwrap();
-        }
-
-        let string = String::from(value);
-        if RE.is_match(value) {
-            Ok(Self(string))
-        } else {
-            Err(ProcessTypeError::InvalidProcessType(string))
-        }
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum ProcessTypeError {
-    #[error(
-        "Found `{0}` but value MUST only contain numbers, letters, and the characters ., _, and -."
-    )]
-    InvalidProcessType(String),
 }
 
 #[cfg(test)]

--- a/libcnb-data/src/lib.rs
+++ b/libcnb-data/src/lib.rs
@@ -22,3 +22,5 @@ pub mod defaults;
 pub mod launch;
 pub mod layer_content_metadata;
 pub mod store;
+
+mod newtypes;

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -1,9 +1,34 @@
 macro_rules! libcnb_newtype {
-    ($name:ident, $error_name:ident, $regex:expr) => {
-        libcnb_newtype!($name, $error_name, $regex, |_| true);
+    (
+        $(#[$type_attributes:meta])*
+        $name:ident,
+        $(#[$error_type_attributes:meta])*
+        $error_name:ident,
+        $regex:expr
+    ) => {
+            libcnb_newtype!(
+                $(#[$type_attributes])*
+                $name,
+                $(#[$error_type_attributes])*
+                $error_name,
+                $regex,
+                |_| true
+            );
     };
-    ($name:ident, $error_name:ident, $regex:expr, $extra_predicate:expr) => {
+    (
+        $(#[$type_attributes:meta])*
+        $name:ident,
+        $(#[$error_type_attributes:meta])*
+        $error_name:ident,
+        $regex:expr,
+        $extra_predicate:expr
+    ) => {
+        #[derive(Debug, Eq, PartialEq, ::serde::Deserialize, ::serde::Serialize)]
+        $(#[$type_attributes])*
+        pub struct $name(String);
+
         #[derive(::thiserror::Error, Debug, Eq, PartialEq)]
+        $(#[$error_type_attributes])*
         pub enum $error_name {
             InvalidValue(String),
         }
@@ -17,9 +42,6 @@ macro_rules! libcnb_newtype {
                 }
             }
         }
-
-        #[derive(Debug, Eq, PartialEq, ::serde::Deserialize, ::serde::Serialize)]
-        pub struct $name(String);
 
         impl ::std::str::FromStr for $name {
             type Err = $error_name;

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -1,3 +1,30 @@
+/// Macro to generate newtypes backed by `String`
+///
+/// Automatically implements the following traits for the newtype:
+/// - [`Debug`]
+/// - [`Display`]
+/// - [`Eq`]
+/// - [`PartialEq`]
+/// - [`serde::Deserialize`]
+/// - [`serde::Serialize`]
+/// - [`FromStr`]
+/// - [`Borrow<String>`]
+/// - [`Deref<Target=String>`]
+/// - [`AsRef<String>`]
+///
+/// # Usage:
+/// ```
+/// libcnb_newtype!(
+///     /// RustDoc for the newtype itself (optional)
+///     BuildpackId,
+///     /// RustDoc for the newtype error (optional)
+///     BuildpackIdError,
+///     // The regular expression that must match for the String to be valid
+///     r"^[[:alnum:]./-]+$",
+///     // Additional predicate function to do further validation (optional)
+///     |id| { id != "app" && id != "config" }
+/// );
+/// ```
 macro_rules! libcnb_newtype {
     (
         $(#[$type_attributes:meta])*

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -1,0 +1,118 @@
+macro_rules! libcnb_newtype {
+    ($name:ident, $error_name:ident, $regex:expr) => {
+        libcnb_newtype!($name, $error_name, $regex, |_| true);
+    };
+    ($name:ident, $error_name:ident, $regex:expr, $extra_predicate:expr) => {
+        #[derive(::thiserror::Error, Debug, Eq, PartialEq)]
+        pub enum $error_name {
+            InvalidValue(String),
+        }
+
+        impl ::std::fmt::Display for $error_name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                match self {
+                    $error_name::InvalidValue(value) => {
+                        ::std::write!(f, "Invalid Value: {}", value)
+                    }
+                }
+            }
+        }
+
+        #[derive(Debug, Eq, PartialEq, ::serde::Deserialize, ::serde::Serialize)]
+        pub struct $name(String);
+
+        impl ::std::str::FromStr for $name {
+            type Err = $error_name;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                let regex_matches = ::regex::Regex::new($regex).unwrap().is_match(value);
+                let predicate_matches = $extra_predicate(value);
+
+                if regex_matches && predicate_matches {
+                    Ok(Self(String::from(value)))
+                } else {
+                    Err($error_name::InvalidValue(String::from(value)))
+                }
+            }
+        }
+
+        impl ::std::borrow::Borrow<String> for $name {
+            fn borrow(&self) -> &String {
+                &self.0
+            }
+        }
+
+        impl ::std::ops::Deref for $name {
+            type Target = String;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl ::std::convert::AsRef<String> for $name {
+            fn as_ref(&self) -> &String {
+                &self.0
+            }
+        }
+
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                ::std::write!(f, "{}", self.0)
+            }
+        }
+    };
+}
+
+pub(crate) use libcnb_newtype;
+
+#[cfg(test)]
+mod test {
+    use super::libcnb_newtype;
+
+    #[test]
+    fn test() {
+        libcnb_newtype!(CapitalizedName, CapitalizedNameError, r"^[A-Z][a-z]*$");
+
+        assert!("Manuel".parse::<CapitalizedName>().is_ok());
+
+        assert_eq!(
+            "manuel".parse::<CapitalizedName>(),
+            Err(CapitalizedNameError::InvalidValue(String::from("manuel")))
+        );
+    }
+
+    #[test]
+    fn test_extra_predicate() {
+        libcnb_newtype!(
+            CapitalizedName,
+            CapitalizedNameError,
+            r"^[A-Z][a-z]*$",
+            |value| value != "Manuel"
+        );
+
+        assert!("Jonas".parse::<CapitalizedName>().is_ok());
+
+        assert_eq!(
+            "manuel".parse::<CapitalizedName>(),
+            Err(CapitalizedNameError::InvalidValue(String::from("manuel")))
+        );
+
+        assert_eq!(
+            "Manuel".parse::<CapitalizedName>(),
+            Err(CapitalizedNameError::InvalidValue(String::from("Manuel")))
+        );
+    }
+
+    #[test]
+    fn test_deref() {
+        libcnb_newtype!(CapitalizedName, CapitalizedNameError, r"^[A-Z][a-z]*$");
+
+        fn foo(name: &str) {
+            assert_eq!(name, "Johanna");
+        }
+
+        let name = "Johanna".parse::<CapitalizedName>().unwrap();
+        foo(&name);
+    }
+}


### PR DESCRIPTION
The macro generates consistent newtypes and their trait implementations across `libcnb-data`. Existing newtypes have been changed to use this macro but are otherwise unmodified and keep their tests and docs.

The macro improves interoperability or our newtypes with `String` and `str` by implementing `Deref`, `Borrow` and `AsRef`. You can now use newtypes from `libcnb-data` interchangeably with `String` and `&str`. Examples:

```rust
let stack_id: StackId = "heroku-20".parse().unwrap();

assert_eq!("HEROKU-20", stack_id.to_uppercase());

fn length(s: &str) -> usize {
    s.len()
}

assert_eq!(9, length(&stack_id));
```

`libcnb-data` newtypes now consistently implement:
- `Debug` 
- `Display`
- `Eq`
- `PartialEq`
- `serde::Deserialize`
- `serde::Serialize`
- `FromStr`
- `Borrow<String>`
- `Deref<Target=String>`
- `AsRef<String>`
