### PR TITLE
Implement Clone for LayerEnv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,5 +27,6 @@
 - Add `PartialEq` implementation for `LayerContentMetadata`.
 - Add `PartialEq` and `Eq` implementations for `LayerTypes`.
 - Add `LayerEnv::chainable_insert`
+- `LayerEnv` and `ModificationBehavior` now implement `Clone`.
 
 ## [0.3.0] 2021/09/17

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -82,7 +82,7 @@ use crate::Env;
 /// assert_eq!(modified_env.get("PATH").unwrap(), layer_dir.join("bin"));
 /// assert_eq!(modified_env.get("CPATH"), None); // None, because CPATH is only added during build
 /// ```
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub struct LayerEnv {
     all: LayerEnvDelta,
     build: LayerEnvDelta,
@@ -385,7 +385,7 @@ impl Default for LayerEnv {
 
 /// Environment variable modification behavior.
 /// ([CNB spec: Environment Variable Modification Rules](https://github.com/buildpacks/spec/blob/main/buildpack.md#environment-variable-modification-rules))
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ModificationBehavior {
     Append,
     Default,
@@ -427,7 +427,7 @@ pub enum TargetLifecycle {
     Process(String),
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 struct LayerEnvDelta {
     entries: BTreeMap<(ModificationBehavior, OsString), OsString>,
 }


### PR DESCRIPTION
Required to fix the default implementation of `Layer::update` in #144 