### PR TITLE
Add LayerName newtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Made it easier to work with buildpack errors during all phases of a `LayerLifecycle`.
 - `LayerEnv` was integrated into the `LayerLifecycle`, allowing buildpack authors to both write environment variables
   in a declarative way and using them between different layers without explicit IO.
+- Introduce `LayerName` for layer names to enforce layer name constraints in the CNB specification.
 - Layer types are no longer part of create/update in `LayerLifecycle`. They moved up to the layer itself, allowing the
   implementation of implicit layer handling when no update or crate happens.
 - New trait design for `LayerLifecycle` which also was renamed to `Layer`.

--- a/libcnb-data/src/layer.rs
+++ b/libcnb-data/src/layer.rs
@@ -2,7 +2,41 @@ use crate::newtypes::libcnb_newtype;
 
 libcnb_newtype!(
     layer,
+    /// Construct a [`LayerName`] value at compile time.
+    ///
+    /// Passing a string that is not a valid `LayerName` value will yield a compilation error.
+    ///
+    /// # Examples:
+    /// ```
+    /// use libcnb_data::layer_name;
+    /// use libcnb_data::layer::LayerName;
+    ///
+    /// let layer_name: LayerName = layer_name!("foobar");
+    /// ```
     layer_name,
+    /// The name of a layer.
+    ///
+    /// It can contain all characters supported by the filesystem, but MUST NOT be either `build`,
+    /// `launch` or `store`.
+    ///
+    /// Use the [`layer_name`](crate::layer_name) macro to construct a `LayerName` from a literal string. To
+    /// parse a dynamic string into a `LayerName`, use [`str::parse`](str::parse).
+    ///
+    /// # Examples
+    /// ```
+    /// use libcnb_data::layer::LayerName;
+    /// use libcnb_data::layer_name;
+    ///
+    /// let from_literal = layer_name!("foobar");
+    ///
+    /// let input = "foobar";
+    /// let from_dynamic: LayerName = input.parse().unwrap();
+    /// assert_eq!(from_dynamic, from_literal);
+    ///
+    /// let input = "build";
+    /// let invalid: Result<LayerName, _> = input.parse();
+    /// assert!(invalid.is_err());
+    /// ```
     LayerName,
     LayerNameError,
     r"^(?!build|launch|store).*$"

--- a/libcnb-data/src/layer.rs
+++ b/libcnb-data/src/layer.rs
@@ -1,0 +1,9 @@
+use crate::newtypes::libcnb_newtype;
+
+libcnb_newtype!(
+    layer,
+    layer_name,
+    LayerName,
+    LayerNameError,
+    r"^(?!build|launch|store).*$"
+);

--- a/libcnb-data/src/lib.rs
+++ b/libcnb-data/src/lib.rs
@@ -20,6 +20,7 @@ pub mod buildpack;
 pub mod buildpack_plan;
 pub mod defaults;
 pub mod launch;
+pub mod layer;
 pub mod layer_content_metadata;
 pub mod store;
 

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -52,7 +52,7 @@ macro_rules! libcnb_newtype {
         $error_name:ident,
         $regex:expr
     ) => {
-        #[derive(Debug, Eq, PartialEq, ::serde::Deserialize, ::serde::Serialize)]
+        #[derive(Debug, Eq, PartialEq, ::serde::Deserialize, ::serde::Serialize, Clone)]
         $(#[$type_attributes])*
         pub struct $name(String);
 

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -1,6 +1,7 @@
 /// Macro to generate a newtype backed by `String` that is validated by a regular expression.
 ///
 /// Automatically implements the following traits for the newtype:
+/// - [`Clone`]
 /// - [`Debug`]
 /// - [`Display`]
 /// - [`Eq`]

--- a/libcnb/examples/example-02-ruby-sample/src/main.rs
+++ b/libcnb/examples/example-02-ruby-sample/src/main.rs
@@ -1,7 +1,7 @@
 use crate::layers::{BundlerLayer, RubyLayer};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::launch::{Launch, Process};
-use libcnb::data::process_type;
+use libcnb::data::{layer_name, process_type};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
 use libcnb::layer_env::TargetLifecycle;
@@ -36,10 +36,10 @@ impl Buildpack for RubyBuildpack {
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         println!("---> Ruby Buildpack");
 
-        let ruby_layer = context.handle_layer("ruby", RubyLayer)?;
+        let ruby_layer = context.handle_layer(layer_name!("ruby"), RubyLayer)?;
 
         context.handle_layer(
-            "bundler",
+            layer_name!("bundler"),
             BundlerLayer {
                 ruby_env: ruby_layer.env.apply(TargetLifecycle::Build, &Env::new()),
             },

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -3,11 +3,11 @@
 use std::path::PathBuf;
 
 use crate::buildpack::Buildpack;
-use crate::data::store::Store;
-use crate::layer::{HandleLayerErrorOrBuildpackError, Layer, LayerData};
-
 use crate::data::buildpack::StackId;
+use crate::data::layer::LayerName;
+use crate::data::store::Store;
 use crate::data::{buildpack::BuildpackToml, buildpack_plan::BuildpackPlan, launch::Launch};
+use crate::layer::{HandleLayerErrorOrBuildpackError, Layer, LayerData};
 
 /// Context for the build phase execution.
 pub struct BuildContext<B: Buildpack + ?Sized> {
@@ -33,6 +33,7 @@ impl<B: Buildpack + ?Sized> BuildContext<B> {
     /// # Example:
     /// ```
     /// # use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+    /// # use libcnb::data::layer_name;
     /// # use libcnb::data::layer_content_metadata::LayerTypes;
     /// # use libcnb::detect::{DetectContext, DetectResult};
     /// # use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
@@ -54,7 +55,7 @@ impl<B: Buildpack + ?Sized> BuildContext<B> {
     /// #    }
     /// #
     ///     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-    ///         let example_layer = context.handle_layer("example-layer", ExampleLayer)?;
+    ///         let example_layer = context.handle_layer(layer_name!("example-layer"), ExampleLayer)?;
     ///
     ///         println!(
     ///             "Monologue from layer metadata: {}",
@@ -93,10 +94,10 @@ impl<B: Buildpack + ?Sized> BuildContext<B> {
     /// ```
     pub fn handle_layer<L: Layer<Buildpack = B>>(
         &self,
-        name: impl AsRef<str>,
+        layer_name: LayerName,
         layer: L,
     ) -> crate::Result<LayerData<L::Metadata>, B::Error> {
-        crate::layer::handle_layer(self, name.as_ref(), layer).map_err(|error| match error {
+        crate::layer::handle_layer(self, layer_name, layer).map_err(|error| match error {
             HandleLayerErrorOrBuildpackError::HandleLayerError(e) => {
                 crate::Error::HandleLayerError(e)
             }

--- a/libcnb/src/layer/public_interface.rs
+++ b/libcnb/src/layer/public_interface.rs
@@ -1,4 +1,5 @@
 use crate::build::BuildContext;
+use crate::data::layer::LayerName;
 use crate::data::layer_content_metadata::{LayerContentMetadata, LayerTypes};
 use crate::generic::GenericMetadata;
 use crate::layer_env::LayerEnv;
@@ -151,7 +152,7 @@ pub enum MetadataMigration<M> {
 
 /// Information about an existing CNB layer.
 pub struct LayerData<M> {
-    pub name: String,
+    pub name: LayerName,
     /// The layer's path, should not be modified outside of a [`Layer`] implementation.
     pub path: PathBuf,
     pub env: LayerEnv,


### PR DESCRIPTION
Fixes #101 

Note: A follow-up PR will change the RustDoc for other newtypes to match the docs for `layer_name` and `LayerName` to achieve consistency.