### PR TITLE
Refactor Ruby example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,5 +45,6 @@
 - `Stack` is now an enum with `Any` and `Specific` variants, rather than a struct.
 - `StackId` no longer permits IDs of `*`, use `Stack::Any` instead.
 - `BuildpackTomlError::InvalidStarStack` has been replaced by `BuildpackTomlError::InvalidAnyStack`.
+- Update the Ruby example buildpack to no longer use anyhow and better demonstrate the intended way to work with errors.
 
 ## [0.3.0] 2021/09/17

--- a/examples/example-02-ruby-sample/Cargo.toml
+++ b/examples/example-02-ruby-sample/Cargo.toml
@@ -6,12 +6,11 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-anyhow = "1"
 flate2 = "1"
 ureq = "2.2.1"
 sha2 = "0.9"
 tar = "0.4"
 toml = "0.5"
 tempfile = "3"
-"libcnb" = { path = "../../libcnb", features = ["anyhow"]  }
+"libcnb" = { path = "../../libcnb" }
 serde = "1.0.126"

--- a/examples/example-02-ruby-sample/src/layers/bundler.rs
+++ b/examples/example-02-ruby-sample/src/layers/bundler.rs
@@ -41,7 +41,7 @@ impl Layer for BundlerLayer {
 
         util::run_simple_command(
             Command::new("gem")
-                .args(&["install", "bundler", "--no-ri", "--no-rdoc"])
+                .args(&["install", "bundler", "--force"])
                 .envs(&self.ruby_env),
             RubyBuildpackError::GemInstallBundlerCommandError,
             RubyBuildpackError::GemInstallBundlerUnexpectedExitStatus,

--- a/examples/example-02-ruby-sample/src/layers/bundler.rs
+++ b/examples/example-02-ruby-sample/src/layers/bundler.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 use crate::RubyBuildpack;
 use libcnb::build::BuildContext;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
-use libcnb::{Buildpack, Env};
+use libcnb::Env;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct BundlerLayerMetadata {
@@ -36,7 +36,7 @@ impl Layer for BundlerLayer {
         &self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
+    ) -> Result<LayerResult<Self::Metadata>, RubyBuildpackError> {
         println!("---> Installing bundler");
 
         util::run_simple_command(
@@ -74,7 +74,7 @@ impl Layer for BundlerLayer {
         &self,
         context: &BuildContext<Self::Buildpack>,
         layer: &LayerData<Self::Metadata>,
-    ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
+    ) -> Result<ExistingLayerStrategy, RubyBuildpackError> {
         util::sha256_checksum(context.app_dir.join("Gemfile.lock"))
             .map_err(RubyBuildpackError::CouldNotGenerateChecksum)
             .map(|checksum| {
@@ -90,7 +90,7 @@ impl Layer for BundlerLayer {
         &self,
         context: &BuildContext<Self::Buildpack>,
         layer: &LayerData<Self::Metadata>,
-    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
+    ) -> Result<LayerResult<Self::Metadata>, RubyBuildpackError> {
         println!("---> Reusing gems");
 
         util::run_simple_command(

--- a/examples/example-02-ruby-sample/src/layers/ruby.rs
+++ b/examples/example-02-ruby-sample/src/layers/ruby.rs
@@ -10,7 +10,6 @@ use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, TargetLifecycle};
-use libcnb::Buildpack;
 
 pub struct RubyLayer;
 
@@ -30,7 +29,7 @@ impl Layer for RubyLayer {
         &self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
+    ) -> Result<LayerResult<Self::Metadata>, RubyBuildpackError> {
         println!("---> Download and extracting Ruby");
 
         let ruby_tgz =

--- a/examples/example-02-ruby-sample/src/util.rs
+++ b/examples/example-02-ruby-sample/src/util.rs
@@ -1,0 +1,46 @@
+use flate2::read::GzDecoder;
+use sha2::Digest;
+use std::fs;
+use std::io;
+use std::path::Path;
+use tar::Archive;
+
+pub fn download(uri: impl AsRef<str>, destination: impl AsRef<Path>) -> Result<(), DownloadError> {
+    let mut response_reader = ureq::get(uri.as_ref())
+        .call()
+        .map_err(DownloadError::RequestError)?
+        .into_reader();
+
+    let mut destination_file = fs::File::create(destination.as_ref())
+        .map_err(DownloadError::CouldNotCreateDestinationFile)?;
+
+    io::copy(&mut response_reader, &mut destination_file)
+        .map_err(DownloadError::CouldNotWriteDestinationFile)?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum DownloadError {
+    RequestError(ureq::Error),
+    CouldNotCreateDestinationFile(std::io::Error),
+    CouldNotWriteDestinationFile(std::io::Error),
+}
+
+pub fn untar(path: impl AsRef<Path>, destination: impl AsRef<Path>) -> Result<(), UntarError> {
+    let file = fs::File::open(path.as_ref()).map_err(UntarError::CouldNotOpenFile)?;
+
+    Archive::new(GzDecoder::new(file))
+        .unpack(destination.as_ref())
+        .map_err(UntarError::CouldNotUnpack)
+}
+
+#[derive(Debug)]
+pub enum UntarError {
+    CouldNotOpenFile(std::io::Error),
+    CouldNotUnpack(std::io::Error),
+}
+
+pub fn sha256_checksum(path: impl AsRef<Path>) -> Result<String, std::io::Error> {
+    fs::read(path).map(|bytes| format!("{:x}", sha2::Sha256::digest(bytes.as_ref())))
+}


### PR DESCRIPTION
This refactors the Ruby example (again) to better show best practices and intended usage of `libcnb`. The main focus was to fix #167 but some other improvements have snuck in.

I had to remove the `--no-ri` and `--no-rdoc` flags when installing bundler and add `--force` to make it work. I assume the errors didn't surface before this refactor.

We should ask @schneems to review the Ruby example for soundness WRT Ruby outside of this PR.

Fixes #167 