### PR TITLE
Remove `Display` trait bound for `Buildpack::Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,5 +41,6 @@
   point and are potential footguns. Implementing a `Layer` should work for all use-cases.
 - The `stack_id` field in `BuildContext` and `DetectContext` is now of type `StackId` instead of `String`.
 - Remove `defaults` module from libcnb-data.
+- Remove `Display` trait bound from `Buildpack::Error` type.
 
 ## [0.3.0] 2021/09/17

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -2,7 +2,7 @@ use crate::build::{BuildContext, BuildResult};
 use crate::detect::{DetectContext, DetectResult};
 use crate::Platform;
 use serde::de::DeserializeOwned;
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 
 /// Represents a buildpack written with the libcnb framework.
 ///
@@ -24,7 +24,7 @@ pub trait Buildpack {
     /// enum are: `MavenExecutionFailed`, `InvalidGemfileLock`, `IncompatiblePythonVersion`. The
     /// framework itself has its [own error type](crate::error::Error) that contains more low-level errors that can occur
     /// during buildpack execution.
-    type Error: Debug + Display;
+    type Error: Debug;
 
     /// Detect logic for this buildpack. Directly corresponds to
     /// [detect in the CNB buildpack interface](https://github.com/buildpacks/spec/blob/platform/v0.6/buildpack.md#detection).
@@ -45,7 +45,7 @@ pub trait Buildpack {
     /// (using its [`Display`] implementation) to stderr.
     fn handle_error(&self, error: crate::Error<Self::Error>) -> i32 {
         eprintln!("Unhandled error:");
-        eprintln!("> {}", error);
+        eprintln!("> {:?}", error);
         eprintln!("Buildpack will exit!");
         100
     }

--- a/libcnb/src/error.rs
+++ b/libcnb/src/error.rs
@@ -2,7 +2,7 @@ use crate::data::buildpack::StackIdError;
 use crate::data::launch::ProcessTypeError;
 use crate::layer::HandleLayerError;
 use crate::toml_file::TomlFileError;
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 
 /// A specialized Result type for libcnb.
 ///
@@ -11,7 +11,7 @@ pub type Result<T, E> = std::result::Result<T, Error<E>>;
 
 /// An error that occurred during buildpack execution.
 #[derive(thiserror::Error, Debug)]
-pub enum Error<E: Debug + Display> {
+pub enum Error<E: Debug> {
     #[error("HandleLayer error: {0}")]
     HandleLayerError(#[from] HandleLayerError),
 
@@ -48,7 +48,7 @@ pub enum Error<E: Debug + Display> {
     #[error("Cannot write store.toml: {0}")]
     CannotWriteStore(TomlFileError),
 
-    #[error("Buildpack error: {0}")]
+    #[error("Buildpack error: {0:?}")]
     BuildpackError(E),
 }
 

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -14,7 +14,7 @@ use crate::error::Error;
 use crate::platform::Platform;
 use crate::toml_file::{read_toml_file, write_toml_file};
 use crate::{Result, LIBCNB_SUPPORTED_BUILDPACK_API};
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 
 /// Main entry point for this framework.
 ///
@@ -200,13 +200,13 @@ fn parse_build_args_or_exit() -> BuildArgs {
     }
 }
 
-fn read_buildpack_dir<E: Display + Debug>() -> Result<PathBuf, E> {
+fn read_buildpack_dir<E: Debug>() -> crate::Result<PathBuf, E> {
     env::var("CNB_BUILDPACK_DIR")
         .map_err(Error::CannotDetermineBuildpackDirectory)
         .map(PathBuf::from)
 }
 
-fn read_buildpack_toml<BM: DeserializeOwned, E: Display + Debug>() -> Result<BuildpackToml<BM>, E> {
+fn read_buildpack_toml<BM: DeserializeOwned, E: Debug>() -> crate::Result<BuildpackToml<BM>, E> {
     read_buildpack_dir().and_then(|buildpack_dir| {
         read_toml_file(buildpack_dir.join("buildpack.toml"))
             .map_err(Error::CannotReadBuildpackDescriptor)


### PR DESCRIPTION
This bound was only necessary for the default implementation of `Buildpack::handle_error`. However, we can provide a useful implementation without it by just using `Debug` for buildpack specific errors. This makes it easier to start working on a buildpack as `Debug` can be derived (`Display` cannot).

In practice, buildpack authors should always implement `Buildpack::handle_error` where they can decide to rely on `Display`, independently from the framework.