### PR TITLE
Adjust `Stack` and `StackId` to better model the "any" stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,5 +42,8 @@
 - The `stack_id` field in `BuildContext` and `DetectContext` is now of type `StackId` instead of `String`.
 - Remove `defaults` module from libcnb-data.
 - Remove `Display` trait bound from `Buildpack::Error` type.
+- `Stack` is now an enum with `Any` and `Specific` variants, rather than a struct.
+- `StackId` no longer permits IDs of `*`, use `Stack::Any` instead.
+- `BuildpackTomlError::InvalidStarStack` has been renamed to `BuildpackTomlError::InvalidAnyStack`.
 
 ## [0.3.0] 2021/09/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,6 @@
 - Remove `Display` trait bound from `Buildpack::Error` type.
 - `Stack` is now an enum with `Any` and `Specific` variants, rather than a struct.
 - `StackId` no longer permits IDs of `*`, use `Stack::Any` instead.
-- `BuildpackTomlError::InvalidStarStack` has been renamed to `BuildpackTomlError::InvalidAnyStack`.
+- `BuildpackTomlError::InvalidStarStack` has been replaced by `BuildpackTomlError::InvalidAnyStack`.
 
 ## [0.3.0] 2021/09/17

--- a/libcnb-data/src/buildpack.rs
+++ b/libcnb-data/src/buildpack.rs
@@ -242,8 +242,7 @@ libcnb_newtype!(
     stack_id,
     /// The ID of a stack.
     ///
-    /// It MUST only contain numbers, letters, and the characters `.`, `/`, and `-`. It can also be
-    /// `*`.
+    /// It MUST only contain numbers, letters, and the characters `.`, `/`, and `-`.
     ///
     /// Use the [`stack_id`](crate::stack_id) macro to construct a `StackId` from a
     /// literal string. To parse a dynamic string into a `StackId`, use

--- a/libcnb-data/src/buildpack.rs
+++ b/libcnb-data/src/buildpack.rs
@@ -101,7 +101,7 @@ impl TryFrom<StackUnchecked> for Stack {
             if mixins.is_empty() {
                 Ok(Stack::Any)
             } else {
-                Err(Self::Error::InvalidAnyStack(mixins.join(", ")))
+                Err(Self::Error::InvalidAnyStack(mixins))
             }
         } else {
             Ok(Stack::Specific {
@@ -273,8 +273,8 @@ pub enum BuildpackTomlError {
     #[error("Found `{0}` but value MUST be in the form `<major>.<minor>` or `<major>` and only contain numbers.")]
     InvalidBuildpackApi(String),
 
-    #[error("Stack with id `*` MUST NOT contain mixins, however the following mixins were specified: {0}")]
-    InvalidAnyStack(String),
+    #[error("Stack with id `*` MUST NOT contain mixins, however the following mixins were specified: `{}`", .0.join("`, `"))]
+    InvalidAnyStack(Vec<String>),
 
     #[error("Invalid Stack ID: {0}")]
     InvalidStackId(#[from] StackIdError),
@@ -508,7 +508,7 @@ mixins = ["foo", "bar"]
         let err = toml::from_str::<GenericBuildpackToml>(raw).unwrap_err();
         assert!(err
             .to_string()
-            .contains("Stack with id `*` MUST NOT contain mixins, however the following mixins were specified: foo, bar"));
+            .contains("Stack with id `*` MUST NOT contain mixins, however the following mixins were specified: `foo`, `bar`"));
     }
 
     #[test]


### PR DESCRIPTION
Previously the "any" stack was modelled as a `Stack` with a `StackId` of `"*"`, and an empty `Vec` of mixins, which does not accurately model the spec:
https://github.com/buildpacks/spec/blob/buildpack/0.6/platform.md#stack-id
https://github.com/buildpacks/spec/blob/buildpack/0.6/buildpack.md#buildpack-implementations

Now:
- `Stack` is an enum with `Any` and `Specific` variants.
-  `StackId` no longer permits IDs of `*`, since `Stack::Any` should be used instead.
- `BuildpackTomlError::InvalidStarStack` has been replaced by `BuildpackTomlError::InvalidAnyStack`.

Fixes #147.
GUS-W-10204027.