### PR TITLE
Fix `LayerName` validation

### DIFF
--- a/libcnb-data/src/layer.rs
+++ b/libcnb-data/src/layer.rs
@@ -39,5 +39,34 @@ libcnb_newtype!(
     /// ```
     LayerName,
     LayerNameError,
-    r"^(?!build|launch|store).*$"
+    r"^(?!(build|launch|store)$).+$"
 );
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn layer_name_validation() {
+        assert!("abc 123_!".parse::<LayerName>().is_ok());
+        assert!("build-foo".parse::<LayerName>().is_ok());
+        assert!("foo-build".parse::<LayerName>().is_ok());
+
+        assert_eq!(
+            "build".parse::<LayerName>(),
+            Err(LayerNameError::InvalidValue(String::from("build")))
+        );
+        assert_eq!(
+            "launch".parse::<LayerName>(),
+            Err(LayerNameError::InvalidValue(String::from("launch")))
+        );
+        assert_eq!(
+            "store".parse::<LayerName>(),
+            Err(LayerNameError::InvalidValue(String::from("store")))
+        );
+        assert_eq!(
+            "".parse::<LayerName>(),
+            Err(LayerNameError::InvalidValue(String::new()))
+        );
+    }
+}


### PR DESCRIPTION
Previously the validation:
- permitted empty string layer names, which should be rejected.
- rejected layer names containing {build,launch,store} as a substring, when those are allowed so long as it's
  only a partial substring.

Tests have now been added.

I didn't add a changelog entry, since this is a bug fix to a change that's already documented in the changelog and not yet released.

Fixes #180.
GUS-W-10219476.