### PR TITLE
Consistently use `tests` as the module name for tests

### DIFF
--- a/libcnb-data/src/layer.rs
+++ b/libcnb-data/src/layer.rs
@@ -43,7 +43,7 @@ libcnb_newtype!(
 );
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -141,11 +141,11 @@ macro_rules! libcnb_newtype {
 pub(crate) use libcnb_newtype;
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::libcnb_newtype;
 
     libcnb_newtype!(
-        newtypes::test,
+        newtypes::tests,
         capitalized_name,
         CapitalizedName,
         CapitalizedNameError,

--- a/libcnb/src/env.rs
+++ b/libcnb/src/env.rs
@@ -95,7 +95,7 @@ impl<'a> IntoIterator for &'a Env {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     #[test]
     #[cfg(target_family = "unix")]
     fn test_into_iterator() {

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -295,7 +295,7 @@ fn read_layer<M: DeserializeOwned, P: AsRef<Path>>(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::data::layer_content_metadata::{LayerContentMetadata, LayerTypes};
     use crate::data::layer_name;

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -592,7 +592,7 @@ impl LayerEnvDelta {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::cmp::Ordering;
     use std::collections::HashMap;
     use std::fs;

--- a/libcnb/src/util.rs
+++ b/libcnb/src/util.rs
@@ -13,7 +13,7 @@ pub(crate) fn default_on_not_found<T: Default>(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::util::default_on_not_found;
     use std::io::ErrorKind;
 


### PR DESCRIPTION
Since we should be consistent, and the idiomatic naming is `tests`:
https://doc.rust-lang.org/book/ch11-03-test-organization.html#unit-tests
https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html

Fixes #188.
GUS-W-10222615.