### PR TITLE
Enable clippy::unnecessary-wraps

### DIFF
--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -16,8 +16,6 @@
 #![allow(clippy::must_use_candidate)]
 // https://github.com/Malax/libcnb.rs/issues/63
 #![allow(clippy::needless_pass_by_value)]
-// https://github.com/Malax/libcnb.rs/issues/64
-#![allow(clippy::unnecessary_wraps)]
 
 pub mod build;
 pub mod detect;


### PR DESCRIPTION
Since it's no longer generating warnings after #144.

https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps

Closes #64.
GUS-W-10169544.