### PR TITLE
Fix newtype `Deserialize` implementation

### DIFF
--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "^1.0.126", features = ["derive"] }
 thiserror = "^1.0.26"
 toml = "^0.5.8"
 libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.1.0" }
+
+[dev-dependencies]
+serde_test = "1.0.130"

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -57,14 +57,6 @@ macro_rules! libcnb_newtype {
         $(#[$type_attributes])*
         pub struct $name(String);
 
-        impl<'de> ::serde::Deserialize<'de> for $name {
-            fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-                String::deserialize(d)?
-                    .parse::<$name>()
-                    .map_err(::serde::de::Error::custom)
-            }
-        }
-
         #[derive(::thiserror::Error, Debug, Eq, PartialEq)]
         $(#[$error_type_attributes])*
         pub enum $error_name {
@@ -94,6 +86,14 @@ macro_rules! libcnb_newtype {
                 } else {
                     Err($error_name::InvalidValue(String::from(value)))
                 }
+            }
+        }
+
+        impl<'de> ::serde::Deserialize<'de> for $name {
+            fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+                String::deserialize(d)?
+                    .parse::<$name>()
+                    .map_err(::serde::de::Error::custom)
             }
         }
 


### PR DESCRIPTION
The derived `Deserialize` implementation does not use the validation logic from `FromStr`. By implementing a custom `Deserialize`, we can ensure it does.

Skips changelog as this is a fix for unreleased code.

Fixes #189 