### PR TITLE
Add more tests for the libcnb_newtype generated types

### DIFF
--- a/libcnb-data/src/buildpack/id.rs
+++ b/libcnb-data/src/buildpack/id.rs
@@ -40,23 +40,46 @@ libcnb_newtype!(
     /// ```
     BuildpackId,
     BuildpackIdError,
-    r"^(?!app$|config$)[[:alnum:]./-]+$"
+    r"^(?!(app|config)$)[[:alnum:]./-]+$"
 );
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
 
     #[test]
-    fn buildpack_id_does_not_allow_app() {
-        let result = BuildpackId::from_str("app");
-        assert!(result.is_err());
+    fn buildpack_id_validation_valid() {
+        assert!("heroku/jvm".parse::<BuildpackId>().is_ok());
+        assert!("Abc123./-".parse::<BuildpackId>().is_ok());
+        assert!("app-foo".parse::<BuildpackId>().is_ok());
+        assert!("foo-app".parse::<BuildpackId>().is_ok());
     }
 
     #[test]
-    fn buildpack_id_does_not_allow_config() {
-        let result = BuildpackId::from_str("config");
-        assert!(result.is_err());
+    fn buildpack_id_validation_invalid() {
+        assert_eq!(
+            "heroku_jvm".parse::<BuildpackId>(),
+            Err(BuildpackIdError::InvalidValue(String::from("heroku_jvm")))
+        );
+        assert_eq!(
+            "heroku:jvm".parse::<BuildpackId>(),
+            Err(BuildpackIdError::InvalidValue(String::from("heroku:jvm")))
+        );
+        assert_eq!(
+            "heroku jvm".parse::<BuildpackId>(),
+            Err(BuildpackIdError::InvalidValue(String::from("heroku jvm")))
+        );
+        assert_eq!(
+            "app".parse::<BuildpackId>(),
+            Err(BuildpackIdError::InvalidValue(String::from("app")))
+        );
+        assert_eq!(
+            "config".parse::<BuildpackId>(),
+            Err(BuildpackIdError::InvalidValue(String::from("config")))
+        );
+        assert_eq!(
+            "".parse::<BuildpackId>(),
+            Err(BuildpackIdError::InvalidValue(String::new()))
+        );
     }
 }

--- a/libcnb-data/src/buildpack/stack_id.rs
+++ b/libcnb-data/src/buildpack/stack_id.rs
@@ -41,3 +41,34 @@ libcnb_newtype!(
     StackIdError,
     r"^[[:alnum:]./-]+$"
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stack_id_validation_valid() {
+        assert!("heroku-20".parse::<StackId>().is_ok());
+        assert!("Abc123./-".parse::<StackId>().is_ok());
+    }
+
+    #[test]
+    fn stack_id_validation_invalid() {
+        assert_eq!(
+            "heroku_20".parse::<StackId>(),
+            Err(StackIdError::InvalidValue(String::from("heroku_20")))
+        );
+        assert_eq!(
+            "heroku:20".parse::<StackId>(),
+            Err(StackIdError::InvalidValue(String::from("heroku:20")))
+        );
+        assert_eq!(
+            "heroku 20".parse::<StackId>(),
+            Err(StackIdError::InvalidValue(String::from("heroku 20")))
+        );
+        assert_eq!(
+            "".parse::<StackId>(),
+            Err(StackIdError::InvalidValue(String::new()))
+        );
+    }
+}

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -128,32 +128,36 @@ libcnb_newtype!(
     /// ```
     ProcessType,
     ProcessTypeError,
-    r"^[[:alnum:]\._-]+$"
+    r"^[[:alnum:]._-]+$"
 );
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
 
     #[test]
-    fn test_process_type_eq() {
-        assert_eq!(
-            ProcessType::from_str("web").unwrap(),
-            ProcessType::from_str("web").unwrap()
-        );
-        assert_ne!(
-            ProcessType::from_str("web").unwrap(),
-            ProcessType::from_str("nope").unwrap()
-        );
+    fn process_type_validation_valid() {
+        assert!("web".parse::<ProcessType>().is_ok());
+        assert!("Abc123._-".parse::<ProcessType>().is_ok());
     }
 
     #[test]
-    fn test_process_type_with_special_chars() {
-        assert!(ProcessType::from_str("java_jar").is_ok());
-        assert!(ProcessType::from_str("java-jar").is_ok());
-        assert!(ProcessType::from_str("java.jar").is_ok());
-
-        assert!(ProcessType::from_str("java~jar").is_err());
+    fn process_type_validation_invalid() {
+        assert_eq!(
+            "worker/foo".parse::<ProcessType>(),
+            Err(ProcessTypeError::InvalidValue(String::from("worker/foo")))
+        );
+        assert_eq!(
+            "worker:foo".parse::<ProcessType>(),
+            Err(ProcessTypeError::InvalidValue(String::from("worker:foo")))
+        );
+        assert_eq!(
+            "worker foo".parse::<ProcessType>(),
+            Err(ProcessTypeError::InvalidValue(String::from("worker foo")))
+        );
+        assert_eq!(
+            "".parse::<ProcessType>(),
+            Err(ProcessTypeError::InvalidValue(String::new()))
+        );
     }
 }

--- a/libcnb-data/src/layer.rs
+++ b/libcnb-data/src/layer.rs
@@ -47,11 +47,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn layer_name_validation() {
-        assert!("abc 123_!".parse::<LayerName>().is_ok());
+    fn layer_name_validation_valid() {
+        assert!("gems".parse::<LayerName>().is_ok());
+        assert!("Abc 123.-_!".parse::<LayerName>().is_ok());
         assert!("build-foo".parse::<LayerName>().is_ok());
         assert!("foo-build".parse::<LayerName>().is_ok());
+    }
 
+    #[test]
+    fn layer_name_validation_invalid() {
         assert_eq!(
             "build".parse::<LayerName>(),
             Err(LayerNameError::InvalidValue(String::from("build")))

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -168,6 +168,18 @@ mod tests {
     }
 
     #[test]
+    fn test_type_eq() {
+        assert_eq!(
+            "Katrin".parse::<CapitalizedName>(),
+            "Katrin".parse::<CapitalizedName>()
+        );
+        assert_ne!(
+            "Katrin".parse::<CapitalizedName>(),
+            "Manuel".parse::<CapitalizedName>()
+        );
+    }
+
+    #[test]
     fn test_literal_macro_success() {
         assert_eq!("Jonas", capitalized_name!("Jonas").as_ref());
     }


### PR DESCRIPTION
Adds tests for the `libcnb_newtype` generated types - specifically that the validation regex is working as expected.

Prompted by #187.

GUS-W-10222615.