### PR TITLE
Add unit tests for `libcnb_data::buildpack::stack`

### DIFF
--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -244,45 +244,4 @@ id = "*"
             ]
         );
     }
-
-    #[test]
-    fn stacks_invalid_stack_id() {
-        let raw = r#"
-api = "0.6"
-
-[buildpack]
-id = "foo/bar"
-name = "Bar Buildpack"
-version = "0.0.1"
-
-[[stacks]]
-id = "io.buildpacks.stacks.*"
-"#;
-
-        let err = toml::from_str::<GenericBuildpackToml>(raw).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Invalid Stack ID: Invalid Value: io.buildpacks.stacks.*"));
-    }
-
-    #[test]
-    fn stacks_invalid_any_stack() {
-        let raw = r#"
-api = "0.6"
-
-[buildpack]
-id = "foo/bar"
-name = "Bar Buildpack"
-version = "0.0.1"
-
-[[stacks]]
-id = "*"
-mixins = ["foo", "bar"]
-"#;
-
-        let err = toml::from_str::<GenericBuildpackToml>(raw).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Stack with id `*` MUST NOT contain mixins, however the following mixins were specified: `foo`, `bar`"));
-    }
 }

--- a/libcnb-data/src/buildpack/stack.rs
+++ b/libcnb-data/src/buildpack/stack.rs
@@ -48,3 +48,69 @@ pub enum StackError {
     #[error("Invalid Stack ID: {0}")]
     InvalidStackId(#[from] StackIdError),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_specific_stack_without_mixins() {
+        let toml_str = r#"
+id = "heroku-20"
+"#;
+        assert_eq!(
+            toml::from_str::<Stack>(toml_str),
+            Ok(Stack::Specific {
+                // Cannot use the `stack_id!` macro due to: https://github.com/Malax/libcnb.rs/issues/179
+                id: "heroku-20".parse().unwrap(),
+                mixins: Vec::new()
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialize_specific_stack_with_mixins() {
+        let toml_str = r#"
+id = "io.buildpacks.stacks.focal"
+mixins = ["build:jq", "wget"]
+"#;
+        assert_eq!(
+            toml::from_str::<Stack>(toml_str),
+            Ok(Stack::Specific {
+                id: "io.buildpacks.stacks.focal".parse().unwrap(),
+                mixins: vec![String::from("build:jq"), String::from("wget")]
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialize_any_stack() {
+        let toml_str = r#"
+id = "*"
+"#;
+        assert_eq!(toml::from_str::<Stack>(toml_str), Ok(Stack::Any));
+    }
+
+    #[test]
+    fn reject_specific_stack_with_invalid_name() {
+        let toml_str = r#"
+id = "io.buildpacks.stacks.*"
+"#;
+        let err = toml::from_str::<Stack>(toml_str).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Invalid Stack ID: Invalid Value: io.buildpacks.stacks.*"));
+    }
+
+    #[test]
+    fn reject_any_stack_with_mixins() {
+        let toml_str = r#"
+id = "*"
+mixins = ["build:jq", "wget"]
+"#;
+        let err = toml::from_str::<Stack>(toml_str).unwrap_err();
+        assert!(err
+                .to_string()
+                .contains("Stack with id `*` MUST NOT contain mixins, however the following mixins were specified: `build:jq`, `wget`"));
+    }
+}


### PR DESCRIPTION
Also removes overlapping unit tests from `libcnb_data::buildpack`, since we don't need to test every single case in the `buildpack.toml` integration tests (note: those integration tests still need some work, which will occur in later PRs).

GUS-W-10222615.