### PR TITLE
Add more unit tests for `libcnb_data::buildpack::api`

### DIFF
--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -45,7 +45,6 @@ use serde::Deserialize;
 /// ```
 #[derive(Deserialize, Debug)]
 pub struct BuildpackToml<BM> {
-    // MUST be in form <major>.<minor> or <major>, where <major> is equivalent to <major>.0.
     pub api: BuildpackApi,
     pub buildpack: Buildpack,
     pub stacks: Vec<Stack>,


### PR DESCRIPTION
The tests have also been changed to exercise parsing of TOML rather than just using `BuildpackApi::from_str()`, since:
- previously the `TryFrom` and serde `Derserialize` implementations were untested (when they are actually what's used in the library), and this approach now tests both
- IMO we should drop support for parsing strings directly (ie: remove the `FromStr` implementation in favour of just having `TryFrom`), which we can now do in a later PR without needing to adjust the tests.

GUS-W-10222615.