### PR TITLE
Simplify BuildpackApi string parsing

### DIFF
--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -12,7 +12,6 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
-lazy_static = "^1.4.0"
 fancy-regex = "^0.7.1"
 semver = { version = "^1.0.4", features = ["serde"] }
 serde = { version = "^1.0.126", features = ["derive"] }


### PR DESCRIPTION
* Removes unnecessary usage of `lazy_static!`, since `BuildpackApi` was only ever parsed once per buildpack invocation, so caching the compiled regex provided no benefit. This is the last usage of that crate, so it has been removed from the crate dependencies.
* Switches from regex to `.split_once()` to simplify implementation.
* Adds a prefix to the description of the `InvalidBuildpackApi` error (style borrowed from `InvalidStackId`), since previously serde deserialization errors included no context as to what field was invalid.
* Removes the description of the version rules from the `InvalidBuildpackApi` error to simplify the error message, since it's not a free-form field (like the buildpack name), so end-users aren't picking their own versions. Instead they need to be picking a known buildpack API version as published upstream. (In the future perhaps `libcnb-data` should be validating against a known/supported versions list too, as another error enum variant.)

GUS-W-10229170.