### PR TITLE
Update example buildpack.toml files

### DIFF
--- a/examples/example-01-basics/buildpack.toml
+++ b/examples/example-01-basics/buildpack.toml
@@ -1,0 +1,9 @@
+api = "0.6"
+
+[buildpack]
+id = "libcnb-examples/basics"
+version = "0.1.0"
+name = "Example libcnb buildpack: basics"
+
+[[stacks]]
+id = "heroku-20"

--- a/examples/example-02-ruby-sample/buildpack.toml
+++ b/examples/example-02-ruby-sample/buildpack.toml
@@ -1,13 +1,10 @@
-# Buildpack API version
 api = "0.6"
 
-# Buildpack ID and metadata
 [buildpack]
-id = "com.examples.buildpacks.ruby"
-version = "0.0.1"
-name = "Ruby Buildpack"
+id = "libcnb-examples/ruby"
+version = "0.1.0"
+name = "Example libcnb buildpack: ruby"
 
-# Stacks that the buildpack will work with
 [[stacks]]
 id = "heroku-20"
 


### PR DESCRIPTION
- `example-01-basics` didn't even have a `buildpack.toml`
- `example-02-ruby` had some (IMO) redundant comments in the file and a weird id.