### PR TITLE
Change DetectResultBuilder and BuildResultBuilder API to match LayerResultBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ impl Buildpack for HelloWorldBuildpack {
     // according to the returned value, handle both writing the build plan and exiting with 
     // the correct status code for you.
     fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
-        Ok(DetectResultBuilder::pass().build())
+        DetectResultBuilder::pass().build()
     }
 
     // Similar to detect, this method will be called when the CNB lifecycle executes the 
@@ -82,7 +82,7 @@ impl Buildpack for HelloWorldBuildpack {
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         println!("Hello World!");
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(BuildResultBuilder::new().build())
+        BuildResultBuilder::new().build()
     }
 }
 

--- a/examples/example-01-basics/src/main.rs
+++ b/examples/example-01-basics/src/main.rs
@@ -10,12 +10,12 @@ impl Buildpack for BasicBuildpack {
     type Error = GenericError;
 
     fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
-        Ok(DetectResultBuilder::pass().build())
+        DetectResultBuilder::pass().build()
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         println!("Build runs on stack {}!", context.stack_id);
-        Ok(BuildResultBuilder::new().build())
+        BuildResultBuilder::new().build()
     }
 }
 

--- a/examples/example-02-ruby-sample/src/main.rs
+++ b/examples/example-02-ruby-sample/src/main.rs
@@ -22,13 +22,11 @@ impl Buildpack for RubyBuildpack {
     type Error = RubyBuildpackError;
 
     fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
-        let result = if context.app_dir.join("Gemfile.lock").exists() {
+        if context.app_dir.join("Gemfile.lock").exists() {
             DetectResultBuilder::pass().build()
         } else {
             DetectResultBuilder::fail().build()
-        };
-
-        Ok(result)
+        }
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
@@ -43,7 +41,7 @@ impl Buildpack for RubyBuildpack {
             },
         )?;
 
-        Ok(BuildResultBuilder::new()
+        BuildResultBuilder::new()
             .launch(
                 Launch::new()
                     .process(Process::new(
@@ -61,7 +59,7 @@ impl Buildpack for RubyBuildpack {
                         false,
                     )),
             )
-            .build())
+            .build()
     }
 }
 

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -62,7 +62,7 @@ impl<B: Buildpack + ?Sized> BuildContext<B> {
     ///             &example_layer.content_metadata.metadata.monologue
     ///         );
     ///
-    ///         Ok(BuildResultBuilder::new().build())
+    ///         BuildResultBuilder::new().build()
     ///     }
     /// }
     ///
@@ -130,13 +130,13 @@ pub(crate) enum InnerBuildResult {
 ///
 /// # Examples:
 /// ```
-/// use libcnb::build::BuildResultBuilder;
+/// use libcnb::build::{BuildResultBuilder, BuildResult};
 /// use libcnb::data::launch::{Launch, Process};
 /// use libcnb::data::process_type;
 ///
-/// let simple = BuildResultBuilder::new().build();
+/// let simple: Result<BuildResult, ()> = BuildResultBuilder::new().build();
 ///
-/// let with_launch = BuildResultBuilder::new()
+/// let with_launch: Result<BuildResult, ()> = BuildResultBuilder::new()
 ///    .launch(Launch::new().process(Process::new(process_type!("type"), "command", vec!["-v"], false, false)))
 ///    .build();
 /// ```
@@ -155,7 +155,18 @@ impl BuildResultBuilder {
 }
 
 impl BuildResultBuilder {
-    pub fn build(self) -> BuildResult {
+    /// Builds the final [`BuildResult`].
+    ///
+    /// This method returns the [`BuildResult`] wrapped in a [`Result`] even though its technically
+    /// not fallible. This is done to simplify using this method in the context it's most often used
+    /// in: a buildpack's [build method](crate::Buildpack::build).
+    ///
+    /// See [`build_unwrapped`](Self::build_unwrapped) for an unwrapped version of this method.
+    pub fn build<E>(self) -> Result<BuildResult, E> {
+        Ok(self.build_unwrapped())
+    }
+
+    pub fn build_unwrapped(self) -> BuildResult {
         BuildResult(InnerBuildResult::Pass {
             launch: self.launch,
             store: self.store,

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -33,13 +33,13 @@ pub(crate) enum InnerDetectResult {
 ///
 /// # Examples:
 /// ```
-/// use libcnb::detect::DetectResultBuilder;
+/// use libcnb::detect::{DetectResultBuilder, DetectResult};
 /// use libcnb_data::build_plan::{BuildPlan, BuildPlanBuilder};
 ///
-/// let simple_pass = DetectResultBuilder::pass().build();
-/// let simple_fail = DetectResultBuilder::fail().build();
+/// let simple_pass: Result<DetectResult, ()> = DetectResultBuilder::pass().build();
+/// let simple_fail: Result<DetectResult, ()> = DetectResultBuilder::fail().build();
 ///
-/// let with_build_plan = DetectResultBuilder::pass()
+/// let with_build_plan: Result<DetectResult, ()> = DetectResultBuilder::pass()
 ///    .build_plan(BuildPlanBuilder::new().provides("something").build())
 ///    .build();
 /// ```
@@ -62,7 +62,18 @@ pub struct PassDetectResultBuilder {
 }
 
 impl PassDetectResultBuilder {
-    pub fn build(self) -> DetectResult {
+    /// Builds the final [`DetectResult`].
+    ///
+    /// This method returns the [`DetectResult`] wrapped in a [`Result`] even though its technically
+    /// not fallible. This is done to simplify using this method in the context it's most often used
+    /// in: a buildpack's [detect method](crate::Buildpack::detect).
+    ///
+    /// See [`build_unwrapped`](Self::build_unwrapped) for an unwrapped version of this method.
+    pub fn build<E>(self) -> Result<DetectResult, E> {
+        Ok(self.build_unwrapped())
+    }
+
+    pub fn build_unwrapped(self) -> DetectResult {
         DetectResult(InnerDetectResult::Pass {
             build_plan: self.build_plan,
         })
@@ -79,8 +90,19 @@ impl PassDetectResultBuilder {
 pub struct FailDetectResultBuilder;
 
 impl FailDetectResultBuilder {
+    /// Builds the final [`DetectResult`].
+    ///
+    /// This method returns the [`DetectResult`] wrapped in a [`Result`] even though its technically
+    /// not fallible. This is done to simplify using this method in the context it's most often used
+    /// in: a buildpack's [detect method](crate::Buildpack::detect).
+    ///
+    /// See [`build_unwrapped`](Self::build_unwrapped) for an unwrapped version of this method.
+    pub fn build<E>(self) -> Result<DetectResult, E> {
+        Ok(self.build_unwrapped())
+    }
+
     #[allow(clippy::unused_self)]
-    pub fn build(self) -> DetectResult {
+    pub fn build_unwrapped(self) -> DetectResult {
         DetectResult(InnerDetectResult::Fail)
     }
 }

--- a/libcnb/src/layer/public_interface.rs
+++ b/libcnb/src/layer/public_interface.rs
@@ -187,10 +187,22 @@ impl<M> LayerResultBuilder<M> {
         self
     }
 
+    /// Builds the final [`LayerResult`].
+    ///
+    /// This method returns the [`LayerResult`] wrapped in a [`Result`] even though its technically
+    /// not fallible. This is done to simplify using this method in the contexts it's most often
+    /// used in: a layer's [create](crate::layer::Layer::create) and/or
+    /// [update](crate::layer::Layer::update) methods.
+    ///
+    /// See [`build_unwrapped`](Self::build_unwrapped) for an unwrapped version of this method.
     pub fn build<E>(self) -> Result<LayerResult<M>, E> {
-        Ok(LayerResult {
+        Ok(self.build_unwrapped())
+    }
+
+    pub fn build_unwrapped(self) -> LayerResult<M> {
+        LayerResult {
             metadata: self.metadata,
             env: self.env,
-        })
+        }
     }
 }

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -62,11 +62,11 @@ const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =
 ///     type Error = GenericError;
 ///
 ///     fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
-///         Ok(DetectResultBuilder::pass().build())
+///         DetectResultBuilder::pass().build()
 ///     }
 ///
 ///     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-///         Ok(BuildResultBuilder::new().build())
+///         BuildResultBuilder::new().build()
 ///     }
 /// }
 ///


### PR DESCRIPTION
`LayerResultBuilder` always wrapped the result of it's build call in a `Result` to simplify usage when used in a `Layer` implementation. This change makes the API for `DetectResultBuilder` and `BuildResultBuilder` match, adds documentation why it returns a `Result` and adds another method to build the respective value without it being wrapped in a `Result`.

Skipping CHANGELOG since this changes unreleased API.