### PR TITLE
Remove TODO from LayerEnv

### DIFF
--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -517,11 +517,7 @@ impl LayerEnvDelta {
 
             if let Some(file_name_stem) = file_name_stem {
                 let modification_behavior = match file_name_extension {
-                    None => {
-                        // TODO: This is different for CNB API versions > 0.5:
-                        // https://github.com/buildpacks/lifecycle/blob/a7428a55c2a14d8a37e84285b95dc63192e3264e/env/env.go#L66-L71
-                        Some(ModificationBehavior::Override)
-                    }
+                    None => Some(ModificationBehavior::Override),
                     Some(file_name_extension) => match file_name_extension.to_str() {
                         Some("append") => Some(ModificationBehavior::Append),
                         Some("default") => Some(ModificationBehavior::Default),


### PR DESCRIPTION
For our next release that targets version 0.6 of the CNB spec, I wanted to check our `LayerEnv` implementation again to ensure it is compatible. I can confirm that it is. The last remaining TODO comment in the code was removed as it was both wrong (override was the default for CNB API versions < 0.5, not the other way around) and we decided to target a single version at a given point in time.