### PR TITLE
Make the `group` field on `buildpack::Order` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,5 +49,6 @@
 - `BuildpackTomlError` has been split into `BuildpackApiError` and `StackError`.
 - `BuildpackApi` no longer implements `FromStr`, use `BuildpackApi::try_from()` instead.
 - Fixed file extension for delimiters when writing `LayerEnv` to disk.
+- Fixed the `group` field on `buildpack::Order` to now be public.
 
 ## [0.3.0] 2021/09/17

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -77,7 +77,7 @@ pub struct License {
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Order {
-    group: Vec<Group>,
+    pub group: Vec<Group>,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]


### PR DESCRIPTION
It being private was an oversight.

This isn't caught be the tests, since they are in the same module.

Fixes #155.
GUS-W-10258076.