### PR TITLE
Adjust .gitignore now Cargo workspaces are being used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-target/
-target-cargo/
+/target/
 .idea
 Cargo.lock


### PR DESCRIPTION
Since:
- The `target/` entry was causing leftover nested target directories to be hidden and not cleaned up.
- The `cargo-target/` entry is redundant as of #199.