### PR TITLE
Remove `test_` prefix from test names

### DIFF
--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -177,7 +177,7 @@ mod tests {
     }
 
     #[test]
-    fn test_type_eq() {
+    fn type_eq() {
         assert_eq!(
             "Katrin".parse::<CapitalizedName>(),
             "Katrin".parse::<CapitalizedName>()
@@ -189,12 +189,12 @@ mod tests {
     }
 
     #[test]
-    fn test_literal_macro_success() {
+    fn literal_macro_success() {
         assert_eq!("Jonas", capitalized_name!("Jonas").as_ref());
     }
 
     #[test]
-    fn test_deref() {
+    fn deref() {
         fn foo(name: &str) {
             assert_eq!(name, "Johanna");
         }
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize() {
+    fn deserialize() {
         assert_de_tokens(&capitalized_name!("Jonas"), &[Token::Str("Jonas")]);
         assert_de_tokens(&capitalized_name!("Johanna"), &[Token::Str("Johanna")]);
 

--- a/libcnb/src/env.rs
+++ b/libcnb/src/env.rs
@@ -98,7 +98,7 @@ impl<'a> IntoIterator for &'a Env {
 mod tests {
     #[test]
     #[cfg(target_family = "unix")]
-    fn test_into_iterator() {
+    fn into_iterator() {
         use crate::Env;
         use std::process::Command;
 

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -602,7 +602,7 @@ mod tests {
     /// Direct port of a test from the reference lifecycle implementation:
     /// See: <https://github.com/buildpacks/lifecycle/blob/a7428a55c2a14d8a37e84285b95dc63192e3264e/env/env_test.go#L105-L154>
     #[test]
-    fn test_reference_impl_env_files_have_a_suffix_it_performs_the_matching_action() {
+    fn reference_impl_env_files_have_a_suffix_it_performs_the_matching_action() {
         let temp_dir = tempdir().unwrap();
 
         let mut files = HashMap::new();
@@ -671,7 +671,7 @@ mod tests {
     /// Direct port of a test from the reference lifecycle implementation:
     /// See: <https://github.com/buildpacks/lifecycle/blob/a7428a55c2a14d8a37e84285b95dc63192e3264e/env/env_test.go#L188-L210>
     #[test]
-    fn test_reference_impl_env_files_have_no_suffix_default_action_is_override() {
+    fn reference_impl_env_files_have_no_suffix_default_action_is_override() {
         let temp_dir = tempdir().unwrap();
 
         let mut files = HashMap::new();
@@ -707,7 +707,7 @@ mod tests {
     /// Direct port of a test from the reference lifecycle implementation:
     /// See: <https://github.com/buildpacks/lifecycle/blob/a7428a55c2a14d8a37e84285b95dc63192e3264e/env/env_test.go#L55-L80>
     #[test]
-    fn test_reference_impl_add_root_dir_should_append_posix_directories() {
+    fn reference_impl_add_root_dir_should_append_posix_directories() {
         let temp_dir = tempdir().unwrap();
         fs::create_dir_all(temp_dir.path().join("bin")).unwrap();
         fs::create_dir_all(temp_dir.path().join("lib")).unwrap();
@@ -744,7 +744,7 @@ mod tests {
     }
 
     #[test]
-    fn test_layer_env_delta_fs_read_write() {
+    fn layer_env_delta_fs_read_write() {
         let mut original_delta = LayerEnvDelta::new();
         original_delta.insert(ModificationBehavior::Append, "APPEND_TO_ME", "NEW_VALUE");
         original_delta.insert(
@@ -773,7 +773,7 @@ mod tests {
     }
 
     #[test]
-    fn test_layer_env_insert() {
+    fn layer_env_insert() {
         let mut layer_env = LayerEnv::new();
         layer_env.insert(
             TargetLifecycle::Build,
@@ -814,7 +814,7 @@ mod tests {
     }
 
     #[test]
-    fn test_modification_behavior_order() {
+    fn modification_behavior_order() {
         let tests = vec![
             (
                 ModificationBehavior::Append,
@@ -849,7 +849,7 @@ mod tests {
     }
 
     #[test]
-    fn test_layer_env_delta_eq() {
+    fn layer_env_delta_eq() {
         let mut delta_1 = LayerEnvDelta::new();
         delta_1.insert(ModificationBehavior::Default, "a", "avalue");
         delta_1.insert(ModificationBehavior::Default, "b", "bvalue");
@@ -864,7 +864,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_from_layer_dir_layer_paths_launch() {
+    fn read_from_layer_dir_layer_paths_launch() {
         let temp_dir = tempdir().unwrap();
         let layer_dir = temp_dir.path();
 
@@ -889,7 +889,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_from_layer_dir_layer_paths_build() {
+    fn read_from_layer_dir_layer_paths_build() {
         let temp_dir = tempdir().unwrap();
         let layer_dir = temp_dir.path();
 


### PR DESCRIPTION
Previously the test names in this repo were inconsistent, with some tests having the `test_` prefix, and others not.

Since tests are marked with a `#[test]` attribute, the `test_` prefix seems redundant, so I've chosen to remove it, rather than add it to the tests that didn't have it.

Fixes #201.