### PR TITLE
Remove "authors" field from Cargo metadata

### DIFF
--- a/examples/example-01-basics/Cargo.toml
+++ b/examples/example-01-basics/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "example-01-basics"
 version = "0.1.0"
-authors = ["Manuel Fuchs <malax@malax.de>"]
 edition = "2021"
 rust-version = "1.56"
 

--- a/examples/example-02-ruby-sample/Cargo.toml
+++ b/examples/example-02-ruby-sample/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "example-02-ruby-sample"
 version = "0.1.0"
-authors = ["Terence Lee <hone02@gmail.com>"]
 edition = "2021"
 rust-version = "1.56"
 

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "libcnb-data"
 version = "0.3.0"
-authors = ["Manuel Fuchs <malax@malax.de>", "Terence Lee <hone02@gmail.com>"]
 edition = "2021"
 rust-version = "1.56"
 license = "BSD-3-Clause"

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "libcnb"
 version = "0.3.0"
-authors = ["Manuel Fuchs <malax@malax.de>", "Terence Lee <hone02@gmail.com>"]
 edition = "2021"
 rust-version = "1.56"
 license = "BSD-3-Clause"


### PR DESCRIPTION
As discussed with @hone, we're removing the `authors` field from Cargo metadata since this project grew beyond a two-man show and we now got contributions from a bunch of other folks. It's hard to come up with rules who should be in the authors field and who shouldn't, so we remove the field entirely (it's not a required field).