### PR TITLE
Remove layer types from hand-written layer metadata in layer::test

### DIFF
--- a/libcnb/src/layer/test.rs
+++ b/libcnb/src/layer/test.rs
@@ -481,11 +481,6 @@ fn update_with_incompatible_metadata_replace() {
     fs::write(
         &test_layer_toml,
         r#"
-[types]
-launch = true
-build = true
-cache = true
-
 [metadata]
 v = "3.2.1"
     "#,
@@ -576,11 +571,6 @@ fn update_with_incompatible_metadata_recreate() {
     fs::write(
         &test_layer_toml,
         r#"
-[types]
-launch = true
-build = true
-cache = true
-
 [metadata]
 versi_on = "3.2.1"
     "#,


### PR DESCRIPTION
The layer types would not be written by the CNB lifecycle, this changes brings the tests closer to reality.