### PR TITLE
Make `libcnb_data::buildpack::Buildpack` name field optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,5 +52,6 @@
 - Fixed file extension for delimiters when writing `LayerEnv` to disk.
 - Fixed the `group` field on `buildpack::Order` to now be public.
 - Add an external Cargo command for packaging libcnb buildpacks. See the README for usage.
+- libcnb_data::buildpack::Buildpack name field is now an Option.
 
 ## [0.3.0] 2021/09/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,6 @@
 - Fixed file extension for delimiters when writing `LayerEnv` to disk.
 - Fixed the `group` field on `buildpack::Order` to now be public.
 - Add an external Cargo command for packaging libcnb buildpacks. See the README for usage.
-- libcnb_data::buildpack::Buildpack name field is now an Option.
+- `libcnb_data::buildpack::Buildpack` name field is now an Option.
 
 ## [0.3.0] 2021/09/17

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -56,7 +56,7 @@ pub struct BuildpackToml<BM> {
 #[derive(Deserialize, Debug)]
 pub struct Buildpack {
     pub id: BuildpackId,
-    pub name: String,
+    pub name: Option<String>,
     // MUST be in the form <X>.<Y>.<Z> where X, Y, and Z are non-negative integers and must not contain leading zeroes
     pub version: Version,
     pub homepage: Option<String>,
@@ -142,7 +142,10 @@ checksum = "abc123"
 
         assert_eq!(buildpack_toml.api, BuildpackApi { major: 0, minor: 6 });
         assert_eq!(buildpack_toml.buildpack.id, "foo/bar".parse().unwrap());
-        assert_eq!(buildpack_toml.buildpack.name, String::from("Bar Buildpack"));
+        assert_eq!(
+            buildpack_toml.buildpack.name,
+            Some(String::from("Bar Buildpack"))
+        );
         assert_eq!(buildpack_toml.buildpack.version, Version::new(0, 0, 1));
         assert_eq!(
             buildpack_toml.buildpack.homepage,
@@ -248,7 +251,10 @@ checksum = "abc123"
 
         assert_eq!(buildpack_toml.api, BuildpackApi { major: 0, minor: 6 });
         assert_eq!(buildpack_toml.buildpack.id, "foo/bar".parse().unwrap());
-        assert_eq!(buildpack_toml.buildpack.name, String::from("Bar Buildpack"));
+        assert_eq!(
+            buildpack_toml.buildpack.name,
+            Some(String::from("Bar Buildpack"))
+        );
         assert_eq!(buildpack_toml.buildpack.version, Version::new(0, 0, 1));
         assert_eq!(
             buildpack_toml.buildpack.homepage,
@@ -324,7 +330,10 @@ id = "*"
 
         assert_eq!(buildpack_toml.api, BuildpackApi { major: 0, minor: 6 });
         assert_eq!(buildpack_toml.buildpack.id, "foo/bar".parse().unwrap());
-        assert_eq!(buildpack_toml.buildpack.name, String::from("Bar Buildpack"));
+        assert_eq!(
+            buildpack_toml.buildpack.name,
+            Some(String::from("Bar Buildpack"))
+        );
         assert_eq!(buildpack_toml.buildpack.version, Version::new(0, 0, 1));
         assert_eq!(buildpack_toml.buildpack.homepage, None);
         assert!(!buildpack_toml.buildpack.clear_env);
@@ -362,7 +371,10 @@ version = "0.0.1"
 
         assert_eq!(buildpack_toml.api, BuildpackApi { major: 0, minor: 6 });
         assert_eq!(buildpack_toml.buildpack.id, "foo/bar".parse().unwrap());
-        assert_eq!(buildpack_toml.buildpack.name, String::from("Bar Buildpack"));
+        assert_eq!(
+            buildpack_toml.buildpack.name,
+            Some(String::from("Bar Buildpack"))
+        );
         assert_eq!(buildpack_toml.buildpack.version, Version::new(0, 0, 1));
         assert_eq!(buildpack_toml.buildpack.homepage, None);
         assert!(!buildpack_toml.buildpack.clear_env);

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -319,7 +319,6 @@ api = "0.6"
 
 [buildpack]
 id = "foo/bar"
-name = "Bar Buildpack"
 version = "0.0.1"
 
 [[stacks]]
@@ -330,10 +329,7 @@ id = "*"
 
         assert_eq!(buildpack_toml.api, BuildpackApi { major: 0, minor: 6 });
         assert_eq!(buildpack_toml.buildpack.id, "foo/bar".parse().unwrap());
-        assert_eq!(
-            buildpack_toml.buildpack.name,
-            Some(String::from("Bar Buildpack"))
-        );
+        assert_eq!(buildpack_toml.buildpack.name, None);
         assert_eq!(buildpack_toml.buildpack.version, Version::new(0, 0, 1));
         assert_eq!(buildpack_toml.buildpack.homepage, None);
         assert!(!buildpack_toml.buildpack.clear_env);
@@ -352,7 +348,6 @@ api = "0.6"
 
 [buildpack]
 id = "foo/bar"
-name = "Bar Buildpack"
 version = "0.0.1"
 
 # This is invalid according to the spec, however libcnb currently requires it:
@@ -371,10 +366,7 @@ version = "0.0.1"
 
         assert_eq!(buildpack_toml.api, BuildpackApi { major: 0, minor: 6 });
         assert_eq!(buildpack_toml.buildpack.id, "foo/bar".parse().unwrap());
-        assert_eq!(
-            buildpack_toml.buildpack.name,
-            Some(String::from("Bar Buildpack"))
-        );
+        assert_eq!(buildpack_toml.buildpack.name, None);
         assert_eq!(buildpack_toml.buildpack.version, Version::new(0, 0, 1));
         assert_eq!(buildpack_toml.buildpack.homepage, None);
         assert!(!buildpack_toml.buildpack.clear_env);

--- a/libcnb/src/layer/test.rs
+++ b/libcnb/src/layer/test.rs
@@ -907,7 +907,7 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
             api: LIBCNB_SUPPORTED_BUILDPACK_API,
             buildpack: crate::data::buildpack::Buildpack {
                 id: buildpack_id!("libcnb/test"),
-                name: "libcnb test buildpack".to_string(),
+                name: None,
                 version: "1.0.0".parse().unwrap(),
                 homepage: None,
                 clear_env: true,

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -35,7 +35,7 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
                 eprintln!("Error: Cloud Native Buildpack API mismatch");
                 eprintln!(
                     "This buildpack ({}) uses Cloud Native Buildpacks API version {}.",
-                    &buildpack_toml.buildpack.name, &buildpack_toml.api,
+                    &buildpack_toml.buildpack.id, &buildpack_toml.api,
                 );
 
                 eprintln!(


### PR DESCRIPTION
Fixes #91 