### PR TITLE
Make `libcnb_data::build_plan::Require` fields public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,6 @@
 - Fixed file extension for delimiters when writing `LayerEnv` to disk.
 - Fixed the `group` field on `buildpack::Order` to now be public.
 - Add an external Cargo command for packaging libcnb buildpacks. See the README for usage.
-- libcnb_data::build_plan::Require fields are now public.
+- `libcnb_data::build_plan::Require` fields are now public.
 
 ## [0.3.0] 2021/09/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,5 +52,6 @@
 - Fixed file extension for delimiters when writing `LayerEnv` to disk.
 - Fixed the `group` field on `buildpack::Order` to now be public.
 - Add an external Cargo command for packaging libcnb buildpacks. See the README for usage.
+- libcnb_data::build_plan::Require fields are now public.
 
 ## [0.3.0] 2021/09/17

--- a/libcnb-data/src/build_plan.rs
+++ b/libcnb-data/src/build_plan.rs
@@ -111,8 +111,8 @@ impl Provide {
 
 #[derive(Serialize, Debug)]
 pub struct Require {
-    name: String,
-    metadata: Table,
+    pub name: String,
+    pub metadata: Table,
 }
 
 impl Require {


### PR DESCRIPTION
This change makes the `Require` fields public so that the current API can be used properly when a buildpack's requirements need metadata. We need to look into an overhaul of the build plan API, but this is out of scope for this PR.

Fixes #197 

