### PR TITLE
Cleanup crate dependencies

### DIFF
--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -14,13 +14,13 @@ name = "cargo-libcnb"
 path = "src/main.rs"
 
 [dependencies]
-toml = "0.5.8"
-libcnb-data = { version = "0.3.0", path = "../libcnb-data" }
 cargo_metadata = "0.14.1"
-which = "4.2.2"
-clap = "2.33.1"
-log = "0.4.14"
-stderrlog = "0.5.1"
-size_format = "1.0.2"
-pathdiff = "0.2.1"
+clap = "2.34.0"
 fs_extra = "1.2.0"
+libcnb-data = { version = "0.3.0", path = "../libcnb-data" }
+log = "0.4.14"
+pathdiff = "0.2.1"
+size_format = "1.0.2"
+stderrlog = "0.5.1"
+toml = "0.5.8"
+which = "4.2.2"

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -11,12 +11,12 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
-fancy-regex = "^0.7.1"
-semver = { version = "^1.0.4", features = ["serde"] }
-serde = { version = "^1.0.126", features = ["derive"] }
-thiserror = "^1.0.26"
-toml = "^0.5.8"
+fancy-regex = "0.7.1"
 libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.1.0" }
+semver = { version = "1.0.4", features = ["serde"] }
+serde = { version = "1.0.130", features = ["derive"] }
+thiserror = "1.0.30"
+toml = "0.5.8"
 
 [dev-dependencies]
 serde_test = "1.0.130"

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -13,6 +13,6 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 proc-macro = true
 
 [dependencies]
-syn = {version = "1.0.81", features = ["full"]}
-quote = "1.0.10"
 fancy-regex = "0.7.1"
+quote = "1.0.10"
+syn = { version = "1.0.82", features = ["full"] }

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -11,12 +11,12 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
-serde = { version = "^1.0.126", features = ["derive"] }
-thiserror = "^1.0.26"
-toml = "^0.5.8"
-anyhow = { version = "^1.0.42", optional = true }
+anyhow = { version = "1.0.51", optional = true }
 libcnb-data = { path = "../libcnb-data", version = "0.3.0" }
+serde = { version = "1.0.130", features = ["derive"] }
+thiserror = "1.0.30"
+toml = "0.5.8"
 
 [dev-dependencies]
-tempfile = "^3.2.0"
 rand = "0.8.4"
+tempfile = "3.2.0"


### PR DESCRIPTION
- Make usage of caret (or not) consistent (by removing it - since the two are functionally equivalent, and the crates.io style is to not use it)
- Sort dependencies alphabetically
- Bump minor/patch versions (a no-op for new installs given library so no lock file, but bumps deps for developing locally where `Cargo.lock` is `.gitignore`d and so goes stale)