### PR TITLE
Correct the data model for `LayerContentMetadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add `must_use` attributes to a number of pure public methods.
 - Remove builder-style methods from `LayerContentMetadata`.
+- Make `LayerContentMetadata`'s `types` field an `Option`.
+- Remove `LayerContentMetadata::Default()`.
 
 ## [0.4.0] 2021/12/08
 

--- a/libcnb/src/layer/test.rs
+++ b/libcnb/src/layer/test.rs
@@ -146,11 +146,11 @@ fn create() {
 
     // Assert layer content metadata, returned and on disk
     let expected_content_layer_metadata = LayerContentMetadata {
-        types: LayerTypes {
+        types: Some(LayerTypes {
             launch: TEST_LAYER_LAUNCH,
             build: TEST_LAYER_BUILD,
             cache: TEST_LAYER_CACHE,
-        },
+        }),
         metadata: TestLayerMetadata {
             version: metadata_version_string,
         },
@@ -215,11 +215,11 @@ fn create_then_update() {
 
     // Assert layer content metadata, returned and on disk
     let expected_content_layer_metadata = LayerContentMetadata {
-        types: LayerTypes {
+        types: Some(LayerTypes {
             launch: TEST_LAYER_LAUNCH,
             build: TEST_LAYER_BUILD,
             cache: TEST_LAYER_CACHE,
-        },
+        }),
         metadata: TestLayerMetadata {
             version: metadata_version_string,
         },
@@ -307,11 +307,11 @@ fn create_then_recreate() {
 
     // Assert layer content metadata, returned and on disk
     let expected_content_layer_metadata = LayerContentMetadata {
-        types: LayerTypes {
+        types: Some(LayerTypes {
             launch: TEST_LAYER_LAUNCH,
             build: TEST_LAYER_BUILD,
             cache: TEST_LAYER_CACHE,
-        },
+        }),
         metadata: TestLayerMetadata {
             version: recreated_metadata_version_string,
         },
@@ -401,11 +401,11 @@ fn create_then_keep() {
 
     // Assert layer content metadata, returned and on disk
     let expected_content_layer_metadata = LayerContentMetadata {
-        types: LayerTypes {
+        types: Some(LayerTypes {
             launch: TEST_LAYER_LAUNCH,
             build: TEST_LAYER_BUILD,
             cache: TEST_LAYER_CACHE,
-        },
+        }),
         metadata: TestLayerMetadata {
             version: metadata_version_string,
         },
@@ -491,11 +491,11 @@ v = "3.2.1"
 
     // Assert layer content metadata, returned and on disk
     let expected_content_layer_metadata = LayerContentMetadata {
-        types: LayerTypes {
+        types: Some(LayerTypes {
             launch: TEST_LAYER_LAUNCH,
             build: TEST_LAYER_BUILD,
             cache: TEST_LAYER_CACHE,
-        },
+        }),
         metadata: TestLayerMetadata {
             // This is the version from a hand-rolled, incompatible metadata TOML file and
             // intentionally not metadata_version_string.
@@ -581,11 +581,11 @@ versi_on = "3.2.1"
 
     // Assert layer content metadata, returned and on disk
     let expected_content_layer_metadata = LayerContentMetadata {
-        types: LayerTypes {
+        types: Some(LayerTypes {
             launch: TEST_LAYER_LAUNCH,
             build: TEST_LAYER_BUILD,
             cache: TEST_LAYER_CACHE,
-        },
+        }),
         metadata: TestLayerMetadata {
             version: metadata_version_string,
         },
@@ -786,7 +786,7 @@ fn default_layer_method_implementations() {
             "bar",
         ),
         content_metadata: LayerContentMetadata {
-            types: LayerTypes::default(),
+            types: Some(LayerTypes::default()),
             metadata: simple_layer_metadata.clone(),
         },
     };


### PR DESCRIPTION
The `types` field of `LayerContentMetadata` is now of type `Option<LayerTypes>` rather than `LayerType`.

This better models the fact that the `[types]` table can be omitted entirely from the layer TOML file, and in fact the table is intentionally removed by the lifecycle when layers are restored in Buildpack API 0.6+.

In addition, `LayerContentMetadata::Default()` has been removed, since:
- It's no longer needed for `#[serde(default)]`.
- It's not really clear what the default for `types` should be (`None` or `LayerTypes::Default()`), and it's probably better if consumers of `LayerContentMetadata` make that choice explicitly.

Lastly, more tests have been added for `LayerContentMetadata`.

Fixes #146.
GUS-W-10289194.