### PR TITLE
Link to PRs from changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## [Unreleased]
 
-- Add `must_use` attributes to a number of pure public methods.
-- Remove builder-style methods from `LayerContentMetadata`.
-- Make `LayerContentMetadata`'s `types` field an `Option`.
-- Remove `LayerContentMetadata::Default()`.
+- Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/Malax/libcnb.rs/pull/232)).
+- Remove builder-style methods from `LayerContentMetadata` ([#235](https://github.com/Malax/libcnb.rs/pull/235)).
+- Make `LayerContentMetadata`'s `types` field an `Option` ([#236](https://github.com/Malax/libcnb.rs/pull/236)).
+- Remove `LayerContentMetadata::Default()` ([#236](https://github.com/Malax/libcnb.rs/pull/236)).
 
 ## [0.4.0] 2021/12/08
 


### PR DESCRIPTION
When consuming other project's changelogs, I find it useful to be able to look at the PR related to a changelog entry, when the changelog entry is not clear, or I want to know more about the motivation/exactly what changed.

This adds PR links for anything newer than v0.4.0 (I don't think it's worth the effort of back-filling previous entries; there was more churn in the project earlier on + fewer users etc).