### PR TITLE
Change the 01-basics example to be compatible with any stack

### DIFF
--- a/examples/example-01-basics/buildpack.toml
+++ b/examples/example-01-basics/buildpack.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 name = "Example libcnb buildpack: basics"
 
 [[stacks]]
-id = "heroku-20"
+id = "*"


### PR DESCRIPTION
This example project isn't dependant on a specific stack, so we can use the `"*"` (any) stack ID.