### PR TITLE
Correct the data model for `buildpack.toml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove `LayerContentMetadata::Default()` ([#236](https://github.com/Malax/libcnb.rs/pull/236)).
 - Switch `Buildpack.version` from type `semver::Version` to `BuildpackVersion`, in order to validate versions more strictly against the CNB spec ([#241](https://github.com/Malax/libcnb.rs/pull/241)).
 - All libcnb-data struct types now reject unrecognised fields when deserializing ([#252](https://github.com/Malax/libcnb.rs/pull/252)).
+- `BuildpackToml` has been replaced by `BuildpackDescriptor`, which is an enum with `Single` and `Meta` variants that wrap new `SingleBuildpackDescriptor` and `MetaBuildpackDescriptor` types. The new types now reject `buildpack.toml` files where both `stacks` and `order` are present ([#248](https://github.com/Malax/libcnb.rs/pull/248)).
 
 ## [0.4.0] 2021/12/08
 

--- a/libcnb-cargo/src/lib.rs
+++ b/libcnb-cargo/src/lib.rs
@@ -6,7 +6,7 @@
 pub mod cross_compile;
 
 use cargo_metadata::MetadataCommand;
-use libcnb_data::buildpack::BuildpackToml;
+use libcnb_data::buildpack::SingleBuildpackDescriptor;
 use std::ffi::OsStr;
 use std::fs;
 use std::io;
@@ -139,7 +139,7 @@ pub enum BuildpackDataError {
 
 pub struct BuildpackData<BM> {
     pub buildpack_toml_path: PathBuf,
-    pub buildpack_toml: BuildpackToml<BM>,
+    pub buildpack_toml: SingleBuildpackDescriptor<BM>,
 }
 
 /// Creates a buildpack directory and copies all buildpack assets to it.
@@ -202,6 +202,8 @@ fn create_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
 ///
 /// This function ensures the resulting name is valid and does not contain problematic characters
 /// such as `/`.
-pub fn default_buildpack_directory_name<BM>(buildpack_toml: &BuildpackToml<BM>) -> String {
+pub fn default_buildpack_directory_name<BM>(
+    buildpack_toml: &SingleBuildpackDescriptor<BM>,
+) -> String {
     buildpack_toml.buildpack.id.replace("/", "_")
 }

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -6,7 +6,9 @@ use crate::buildpack::Buildpack;
 use crate::data::buildpack::StackId;
 use crate::data::layer::LayerName;
 use crate::data::store::Store;
-use crate::data::{buildpack::BuildpackToml, buildpack_plan::BuildpackPlan, launch::Launch};
+use crate::data::{
+    buildpack::SingleBuildpackDescriptor, buildpack_plan::BuildpackPlan, launch::Launch,
+};
 use crate::layer::{HandleLayerErrorOrBuildpackError, Layer, LayerData};
 
 /// Context for the build phase execution.
@@ -17,7 +19,7 @@ pub struct BuildContext<B: Buildpack + ?Sized> {
     pub stack_id: StackId,
     pub platform: B::Platform,
     pub buildpack_plan: BuildpackPlan,
-    pub buildpack_descriptor: BuildpackToml<B::Metadata>,
+    pub buildpack_descriptor: SingleBuildpackDescriptor<B::Metadata>,
 }
 
 impl<B: Buildpack + ?Sized> BuildContext<B> {

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use crate::buildpack::Buildpack;
 use crate::data::buildpack::StackId;
-use crate::{data::build_plan::BuildPlan, data::buildpack::BuildpackToml};
+use crate::{data::build_plan::BuildPlan, data::buildpack::SingleBuildpackDescriptor};
 
 /// Context for the detect phase execution.
 pub struct DetectContext<B: Buildpack + ?Sized> {
@@ -13,7 +13,7 @@ pub struct DetectContext<B: Buildpack + ?Sized> {
     pub buildpack_dir: PathBuf,
     pub stack_id: StackId,
     pub platform: B::Platform,
-    pub buildpack_descriptor: BuildpackToml<B::Metadata>,
+    pub buildpack_descriptor: SingleBuildpackDescriptor<B::Metadata>,
 }
 
 /// Describes the result of the detect phase.

--- a/libcnb/src/layer/test.rs
+++ b/libcnb/src/layer/test.rs
@@ -21,7 +21,7 @@ use crate::layer::{
 };
 use crate::layer_env::{LayerEnv, ModificationBehavior, TargetLifecycle};
 use crate::{read_toml_file, Buildpack, Env, LIBCNB_SUPPORTED_BUILDPACK_API};
-use libcnb_data::buildpack::{BuildpackToml, BuildpackVersion, Stack};
+use libcnb_data::buildpack::{BuildpackVersion, SingleBuildpackDescriptor, Stack};
 use libcnb_data::buildpack_plan::BuildpackPlan;
 use libcnb_data::layer::LayerName;
 use libcnb_data::layer_content_metadata::LayerContentMetadata;
@@ -903,7 +903,7 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
         stack_id: stack_id!("heroku-20"),
         platform: GenericPlatform::new(Env::new()),
         buildpack_plan: BuildpackPlan { entries: vec![] },
-        buildpack_descriptor: BuildpackToml {
+        buildpack_descriptor: SingleBuildpackDescriptor {
             api: LIBCNB_SUPPORTED_BUILDPACK_API,
             buildpack: crate::data::buildpack::Buildpack {
                 id: buildpack_id!("libcnb/test"),
@@ -916,7 +916,6 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
                 licenses: vec![],
             },
             stacks: vec![Stack::Any],
-            order: vec![],
             metadata: GenericMetadata::default(),
         },
     }

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 
 use crate::build::{BuildContext, InnerBuildResult};
 use crate::buildpack::Buildpack;
-use crate::data::buildpack::{BuildpackToml, StackId};
+use crate::data::buildpack::{SingleBuildpackDescriptor, StackId};
 use crate::detect::{DetectContext, InnerDetectResult};
 use crate::error::Error;
 use crate::platform::Platform;
@@ -206,7 +206,8 @@ fn read_buildpack_dir<E: Debug>() -> crate::Result<PathBuf, E> {
         .map(PathBuf::from)
 }
 
-fn read_buildpack_toml<BM: DeserializeOwned, E: Debug>() -> crate::Result<BuildpackToml<BM>, E> {
+fn read_buildpack_toml<BM: DeserializeOwned, E: Debug>(
+) -> crate::Result<SingleBuildpackDescriptor<BM>, E> {
     read_buildpack_dir().and_then(|buildpack_dir| {
         read_toml_file(buildpack_dir.join("buildpack.toml"))
             .map_err(Error::CannotReadBuildpackDescriptor)


### PR DESCRIPTION
The CNB spec states that a `buildpack.toml` must contain exactly one of the tables `stacks` or `order`, but not both - since they relate to different buildpack types (single buildpacks and meta-buildpacks respectively):
https://github.com/buildpacks/spec/blob/main/buildpack.md#buildpack-implementations

Previously `BuildpackToml` attempted to represent both of these as a single type, which both meant the type wasn't an accurate representation, but also that invalid `buildpack.toml` files would pass `libcnb package` validation only to fail later at runtime with a Pack CLI error message.

Now `BuildpackToml` has been replaced with the enum `BuildpackDescriptor`, which has `Single` and `Meta` variants that wrap new `SingleBuildpackDescriptor` and `MetaBuildpackDescriptor` types.

Consumers of libcnb-data can now either parse `buildpack.toml` files using `BuildpackDescriptor` when they wish to support both variants, or else use the specific sub-types when a specific buildpack type is required for improved error messages.

Fixes #211.
GUS-W-10289129.