### PR TITLE
Box `ureq::Error` to prevent `large_enum_variant` errors

### DIFF
--- a/examples/example-02-ruby-sample/src/util.rs
+++ b/examples/example-02-ruby-sample/src/util.rs
@@ -9,7 +9,7 @@ use tar::Archive;
 pub fn download(uri: impl AsRef<str>, destination: impl AsRef<Path>) -> Result<(), DownloadError> {
     let mut response_reader = ureq::get(uri.as_ref())
         .call()
-        .map_err(DownloadError::RequestError)?
+        .map_err(|err| DownloadError::RequestError(Box::new(err)))?
         .into_reader();
 
     let mut destination_file = fs::File::create(destination.as_ref())
@@ -23,7 +23,8 @@ pub fn download(uri: impl AsRef<str>, destination: impl AsRef<Path>) -> Result<(
 
 #[derive(Debug)]
 pub enum DownloadError {
-    RequestError(ureq::Error),
+    // Boxed to prevent `large_enum_variant` errors since `ureq::Error` is massive.
+    RequestError(Box<ureq::Error>),
     CouldNotCreateDestinationFile(std::io::Error),
     CouldNotWriteDestinationFile(std::io::Error),
 }


### PR DESCRIPTION
`ureq::Error` is massive (and increased further between ureq 2.3.1 and 2.4.0), meaning
unless it's boxed, Clippy's ~pedantic~ perf `large_enum_variant` lint fails with:

```
error: large size difference between variants
  --> examples/example-02-ruby-sample/src/util.rs:26:5
   |
26 |     RequestError(ureq::Error),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ this variant is 224 bytes
   |
   = note: `-D clippy::large-enum-variant` implied by `-D warnings`
note: and the second-largest variant is 16 bytes:
  --> examples/example-02-ruby-sample/src/util.rs:27:5
   |
27 |     CouldNotCreateDestinationFile(std::io::Error),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
   |
26 |     RequestError(Box<ureq::Error>),
   |                  ~~~~~~~~~~~~~~~~

error: large size difference between variants
```

Fixes #249.
GUS-W-10387602.