### PR TITLE
Reject unknown fields when deserializing TOML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Make `LayerContentMetadata`'s `types` field an `Option` ([#236](https://github.com/Malax/libcnb.rs/pull/236)).
 - Remove `LayerContentMetadata::Default()` ([#236](https://github.com/Malax/libcnb.rs/pull/236)).
 - Switch `Buildpack.version` from type `semver::Version` to `BuildpackVersion`, in order to validate versions more strictly against the CNB spec ([#241](https://github.com/Malax/libcnb.rs/pull/241)).
+- All libcnb-data struct types now reject unrecognised fields when deserializing ([#252](https://github.com/Malax/libcnb.rs/pull/252)).
 
 ## [0.4.0] 2021/12/08
 

--- a/examples/example-02-ruby-sample/src/main.rs
+++ b/examples/example-02-ruby-sample/src/main.rs
@@ -64,6 +64,7 @@ impl Buildpack for RubyBuildpack {
 }
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct RubyBuildpackMetadata {
     pub ruby_url: String,
 }

--- a/libcnb-data/src/bom.rs
+++ b/libcnb-data/src/bom.rs
@@ -4,6 +4,7 @@ use toml;
 pub type Bom = Vec<Entry>;
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Entry {
     pub name: String,
     pub metadata: toml::value::Table,

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -45,6 +45,7 @@ use serde::Deserialize;
 /// assert!(result.is_ok());
 /// ```
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct BuildpackToml<BM> {
     pub api: BuildpackApi,
     pub buildpack: Buildpack,
@@ -55,6 +56,7 @@ pub struct BuildpackToml<BM> {
 }
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Buildpack {
     pub id: BuildpackId,
     pub name: Option<String>,
@@ -70,17 +72,20 @@ pub struct Buildpack {
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct License {
     pub r#type: Option<String>,
     pub uri: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct Order {
     pub group: Vec<Group>,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct Group {
     pub id: BuildpackId,
     pub version: BuildpackVersion,

--- a/libcnb-data/src/buildpack/stack.rs
+++ b/libcnb-data/src/buildpack/stack.rs
@@ -6,6 +6,7 @@ use super::{StackId, StackIdError};
 // potentially invalid `Stack` data when deserializing
 // https://dev.to/equalma/validate-fields-and-types-in-serde-with-tryfrom-c2n
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct StackUnchecked {
     pub id: String,
     #[serde(default)]

--- a/libcnb-data/src/buildpack_plan.rs
+++ b/libcnb-data/src/buildpack_plan.rs
@@ -2,12 +2,14 @@ use serde::Deserialize;
 use toml::value::Table;
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BuildpackPlan {
     #[serde(default)]
     pub entries: Vec<Entry>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Entry {
     pub name: String,
     #[serde(default)]

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -3,6 +3,7 @@ use crate::newtypes::libcnb_newtype;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Launch {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub bom: bom::Bom,
@@ -53,12 +54,14 @@ impl Default for Launch {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Label {
     pub key: String,
     pub value: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Process {
     pub r#type: ProcessType,
     pub command: String,
@@ -87,6 +90,7 @@ impl Process {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Slice {
     pub paths: Vec<String>,
 }

--- a/libcnb-data/src/layer_content_metadata.rs
+++ b/libcnb-data/src/layer_content_metadata.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// See [Cloud Native Buildpack specification](https://github.com/buildpacks/spec/blob/main/buildpack.md#layer-content-metadata-toml)
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LayerContentMetadata<M> {
     pub types: Option<LayerTypes>,
 
@@ -20,6 +21,7 @@ impl<M: PartialEq> PartialEq for LayerContentMetadata<M> {
 /// Used to specify layer availability based
 /// on buildpack phase.
 #[derive(Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct LayerTypes {
     /// Whether the layer is intended for launch.
     #[serde(default)]

--- a/libcnb-data/src/store.rs
+++ b/libcnb-data/src/store.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use toml::value::Table;
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Store {
     pub metadata: Table,
 }


### PR DESCRIPTION
The Serde attribute `deny_unknown_fields` ensures that any unknown fields cause the parsing of TOML files to fail, making it easier to spot when the file does not match the expected schema.

This will ensure issues like heroku/buildpacks-jvm#227 are spotted sooner.

See:
https://serde.rs/container-attrs.html#deny_unknown_fields

Closes #251.
GUS-W-10393275.