### PR TITLE
Rename remaining `*buildpack_toml` references to `*buildpack_descriptor`

### DIFF
--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- `BuildpackData` and `default_buildpack_directory_name()` have been updated for the libcnb-data replacement of `BuildpackToml` with `*BuildpackDescriptor` ([#248](https://github.com/Malax/libcnb.rs/pull/248).
+- `BuildpackData`, `assemble_buildpack_directory()` and `default_buildpack_directory_name()` have been updated for the libcnb-data replacement of `BuildpackToml` with `*BuildpackDescriptor` and rename of `*buildpack_toml` to `*buildpack_descriptor` ([#248](https://github.com/Malax/libcnb.rs/pull/248) and [#254](https://github.com/Malax/libcnb.rs/pull/254)).
 
 ## [0.1.0] 2021-12-08
 

--- a/libcnb-cargo/src/lib.rs
+++ b/libcnb-cargo/src/lib.rs
@@ -118,16 +118,16 @@ pub enum CargoProfile {
 pub fn read_buildpack_data(
     project_path: impl AsRef<Path>,
 ) -> Result<BuildpackData<Option<toml::Value>>, BuildpackDataError> {
-    let buildpack_toml_path = project_path.as_ref().join("buildpack.toml");
+    let buildpack_descriptor_path = project_path.as_ref().join("buildpack.toml");
 
-    fs::read_to_string(&buildpack_toml_path)
+    fs::read_to_string(&buildpack_descriptor_path)
         .map_err(BuildpackDataError::IoError)
         .and_then(|file_contents| {
             toml::from_str(&file_contents).map_err(BuildpackDataError::DeserializationError)
         })
-        .map(|buildpack_toml| BuildpackData {
-            buildpack_toml_path,
-            buildpack_toml,
+        .map(|buildpack_descriptor| BuildpackData {
+            buildpack_descriptor_path,
+            buildpack_descriptor,
         })
 }
 
@@ -138,8 +138,8 @@ pub enum BuildpackDataError {
 }
 
 pub struct BuildpackData<BM> {
-    pub buildpack_toml_path: PathBuf,
-    pub buildpack_toml: SingleBuildpackDescriptor<BM>,
+    pub buildpack_descriptor_path: PathBuf,
+    pub buildpack_descriptor: SingleBuildpackDescriptor<BM>,
 }
 
 /// Creates a buildpack directory and copies all buildpack assets to it.
@@ -156,7 +156,7 @@ pub struct BuildpackData<BM> {
 /// Will return `Err` if the buildpack directory already exists or could not be assembled.
 pub fn assemble_buildpack_directory(
     destination_path: impl AsRef<Path>,
-    buildpack_toml_path: impl AsRef<Path>,
+    buildpack_descriptor_path: impl AsRef<Path>,
     buildpack_binary_path: impl AsRef<Path>,
 ) -> std::io::Result<()> {
     if destination_path.as_ref().exists() {
@@ -168,7 +168,7 @@ pub fn assemble_buildpack_directory(
         fs::create_dir_all(destination_path.as_ref())?;
 
         fs::copy(
-            buildpack_toml_path.as_ref(),
+            buildpack_descriptor_path.as_ref(),
             destination_path.as_ref().join("buildpack.toml"),
         )?;
 
@@ -203,7 +203,7 @@ fn create_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
 /// This function ensures the resulting name is valid and does not contain problematic characters
 /// such as `/`.
 pub fn default_buildpack_directory_name<BM>(
-    buildpack_toml: &SingleBuildpackDescriptor<BM>,
+    buildpack_descriptor: &SingleBuildpackDescriptor<BM>,
 ) -> String {
-    buildpack_toml.buildpack.id.replace("/", "_")
+    buildpack_descriptor.buildpack.id.replace("/", "_")
 }

--- a/libcnb-cargo/src/main.rs
+++ b/libcnb-cargo/src/main.rs
@@ -78,7 +78,8 @@ fn handle_libcnb_package(matches: &ArgMatches) {
 
     info!(
         "Found buildpack {} with version {}.",
-        buildpack_data.buildpack_toml.buildpack.id, buildpack_data.buildpack_toml.buildpack.version
+        buildpack_data.buildpack_descriptor.buildpack.id,
+        buildpack_data.buildpack_descriptor.buildpack.version
     );
 
     let cargo_metadata = match MetadataCommand::new()
@@ -100,7 +101,7 @@ fn handle_libcnb_package(matches: &ArgMatches) {
             CargoProfile::Release => "release",
         })
         .join(default_buildpack_directory_name(
-            &buildpack_data.buildpack_toml,
+            &buildpack_data.buildpack_descriptor,
         ))
         .into_std_path_buf();
 
@@ -182,7 +183,7 @@ fn handle_libcnb_package(matches: &ArgMatches) {
 
     if let Err(io_error) = assemble_buildpack_directory(
         &output_path,
-        &buildpack_data.buildpack_toml_path,
+        &buildpack_data.buildpack_descriptor_path,
         &binary_path,
     ) {
         error!("IO error while writing buildpack directory: {}", io_error);

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -29,13 +29,13 @@ use std::fmt::Debug;
 /// Don't implement this directly and use the [`buildpack_main`] macro instead!
 #[doc(hidden)]
 pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
-    match read_buildpack_toml::<B::Metadata, B::Error>() {
-        Ok(buildpack_toml) => {
-            if buildpack_toml.api != LIBCNB_SUPPORTED_BUILDPACK_API {
+    match read_buildpack_descriptor::<B::Metadata, B::Error>() {
+        Ok(buildpack_descriptor) => {
+            if buildpack_descriptor.api != LIBCNB_SUPPORTED_BUILDPACK_API {
                 eprintln!("Error: Cloud Native Buildpack API mismatch");
                 eprintln!(
                     "This buildpack ({}) uses Cloud Native Buildpacks API version {}.",
-                    &buildpack_toml.buildpack.id, &buildpack_toml.api,
+                    &buildpack_descriptor.buildpack.id, &buildpack_descriptor.api,
                 );
 
                 eprintln!(
@@ -100,7 +100,7 @@ fn libcnb_runtime_detect<B: Buildpack>(buildpack: &B) -> crate::Result<(), B::Er
         stack_id,
         platform,
         buildpack_dir: read_buildpack_dir()?,
-        buildpack_descriptor: read_buildpack_toml()?,
+        buildpack_descriptor: read_buildpack_descriptor()?,
     };
 
     match buildpack.detect(detect_context)?.0 {
@@ -140,7 +140,7 @@ fn libcnb_runtime_build<B: Buildpack>(buildpack: &B) -> crate::Result<(), B::Err
         platform,
         buildpack_plan,
         buildpack_dir: read_buildpack_dir()?,
-        buildpack_descriptor: read_buildpack_toml()?,
+        buildpack_descriptor: read_buildpack_descriptor()?,
     })?;
 
     match build_result.0 {
@@ -206,7 +206,7 @@ fn read_buildpack_dir<E: Debug>() -> crate::Result<PathBuf, E> {
         .map(PathBuf::from)
 }
 
-fn read_buildpack_toml<BM: DeserializeOwned, E: Debug>(
+fn read_buildpack_descriptor<BM: DeserializeOwned, E: Debug>(
 ) -> crate::Result<SingleBuildpackDescriptor<BM>, E> {
     read_buildpack_dir().and_then(|buildpack_dir| {
         read_toml_file(buildpack_dir.join("buildpack.toml"))


### PR DESCRIPTION
To complete the work started in #248.

Closes #168.
GUS-W-10289129.