### PR TITLE
Rename `TargetLifecycle` to `Scope`

### DIFF
--- a/examples/example-02-ruby-sample/src/layers/ruby.rs
+++ b/examples/example-02-ruby-sample/src/layers/ruby.rs
@@ -9,7 +9,7 @@ use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
-use libcnb::layer_env::{LayerEnv, ModificationBehavior, TargetLifecycle};
+use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 
 pub struct RubyLayer;
 
@@ -47,13 +47,13 @@ impl Layer for RubyLayer {
             .env(
                 LayerEnv::new()
                     .chainable_insert(
-                        TargetLifecycle::All,
+                        Scope::All,
                         ModificationBehavior::Prepend,
                         "PATH",
                         context.app_dir.join(".gem/ruby/2.6.6/bin"),
                     )
                     .chainable_insert(
-                        TargetLifecycle::All,
+                        Scope::All,
                         ModificationBehavior::Prepend,
                         "LD_LIBRARY_PATH",
                         layer_path,

--- a/examples/example-02-ruby-sample/src/main.rs
+++ b/examples/example-02-ruby-sample/src/main.rs
@@ -4,7 +4,7 @@ use libcnb::data::launch::{Launch, Process};
 use libcnb::data::{layer_name, process_type};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
-use libcnb::layer_env::TargetLifecycle;
+use libcnb::layer_env::Scope;
 use libcnb::{buildpack_main, Buildpack, Env};
 
 use crate::util::{DownloadError, UntarError};
@@ -37,7 +37,7 @@ impl Buildpack for RubyBuildpack {
         context.handle_layer(
             layer_name!("bundler"),
             BundlerLayer {
-                ruby_env: ruby_layer.env.apply(TargetLifecycle::Build, &Env::new()),
+                ruby_env: ruby_layer.env.apply(Scope::Build, &Env::new()),
             },
         )?;
 

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/Malax/libcnb.rs/pull/232)).
+- `TargetLifecycle` has been renamed to `Scope` ([#257](https://github.com/Malax/libcnb.rs/pull/257)).
 
 ## [0.4.0] 2021-12-08
 

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -298,7 +298,7 @@ mod tests {
     use crate::data::layer_content_metadata::{LayerContentMetadata, LayerTypes};
     use crate::data::layer_name;
     use crate::generic::GenericMetadata;
-    use crate::layer_env::{ModificationBehavior, TargetLifecycle};
+    use crate::layer_env::{ModificationBehavior, Scope};
     use crate::{read_toml_file, Env};
     use serde::Deserialize;
     use std::ffi::OsString;
@@ -375,7 +375,7 @@ mod tests {
             &layers_dir,
             &layer_name,
             &LayerEnv::new().chainable_insert(
-                TargetLifecycle::All,
+                Scope::All,
                 ModificationBehavior::Default,
                 "ENV_VAR",
                 "ENV_VAR_VALUE",
@@ -423,13 +423,13 @@ mod tests {
             &layer_name,
             &LayerEnv::new()
                 .chainable_insert(
-                    TargetLifecycle::All,
+                    Scope::All,
                     ModificationBehavior::Default,
                     "ENV_VAR",
                     "INITIAL_ENV_VAR_VALUE",
                 )
                 .chainable_insert(
-                    TargetLifecycle::All,
+                    Scope::All,
                     ModificationBehavior::Default,
                     "SOME_OTHER_ENV_VAR",
                     "SOME_OTHER_ENV_VAR_VALUE",
@@ -451,7 +451,7 @@ mod tests {
             &layers_dir,
             &layer_name,
             &LayerEnv::new().chainable_insert(
-                TargetLifecycle::All,
+                Scope::All,
                 ModificationBehavior::Default,
                 "ENV_VAR",
                 "NEW_ENV_VAR_VALUE",
@@ -557,7 +557,7 @@ mod tests {
             }
         );
 
-        let applied_layer_env = layer_data.env.apply(TargetLifecycle::Build, &Env::new());
+        let applied_layer_env = layer_data.env.apply(Scope::Build, &Env::new());
         assert_eq!(
             applied_layer_env.get("PATH"),
             Some(layer_dir.join("bin").into())

--- a/libcnb/src/layer/test.rs
+++ b/libcnb/src/layer/test.rs
@@ -19,7 +19,7 @@ use crate::layer::{
     handle_layer, ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder,
     MetadataMigration,
 };
-use crate::layer_env::{LayerEnv, ModificationBehavior, TargetLifecycle};
+use crate::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use crate::{read_toml_file, Buildpack, Env, LIBCNB_SUPPORTED_BUILDPACK_API};
 use libcnb_data::buildpack::{BuildpackVersion, SingleBuildpackDescriptor, Stack};
 use libcnb_data::buildpack_plan::BuildpackPlan;
@@ -708,7 +708,7 @@ fn write_layer_env() {
     let layer_name = random_layer_name();
     let metadata_version_string = String::from("1.0.0");
     let layer_env = LayerEnv::new().chainable_insert(
-        TargetLifecycle::All,
+        Scope::All,
         ModificationBehavior::Append,
         "RANDOM",
         "4", // chosen by fair dice roll, guaranteed to be random.
@@ -780,7 +780,7 @@ fn default_layer_method_implementations() {
         name: layer_name,
         path: PathBuf::default(),
         env: LayerEnv::new().chainable_insert(
-            TargetLifecycle::All,
+            Scope::All,
             ModificationBehavior::Default,
             "FOO",
             "bar",
@@ -871,7 +871,7 @@ fn layer_env_read_write() {
 
     let layer = LayerDataTestLayer {
         expected_layer_env: LayerEnv::new().chainable_insert(
-            TargetLifecycle::All,
+            Scope::All,
             ModificationBehavior::Override,
             "FOO",
             "bar",


### PR DESCRIPTION
To make its purpose clearer.

Fixes #170.
GUS-W-10415008.