### PR TITLE
Implement `Borrow<str>` for types generated using `libcnb_newtype!`

### DIFF
--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Switch `Buildpack.version` from type `semver::Version` to `BuildpackVersion`, in order to validate versions more strictly against the CNB spec ([#241](https://github.com/Malax/libcnb.rs/pull/241)).
 - All libcnb-data struct types now reject unrecognised fields when deserializing ([#252](https://github.com/Malax/libcnb.rs/pull/252)).
 - `BuildpackToml` has been replaced by `BuildpackDescriptor`, which is an enum with `Single` and `Meta` variants that wrap new `SingleBuildpackDescriptor` and `MetaBuildpackDescriptor` types. The new types now reject `buildpack.toml` files where both `stacks` and `order` are present ([#248](https://github.com/Malax/libcnb.rs/pull/248)).
+- Implement `Borrow<str>` for types generated using the `libcnb_newtype!` macro (currently `BuildpackId`, `LayerName`, `ProcessType` and `StackId`), which allows them to be used with `.join()` ([#258](https://github.com/Malax/libcnb.rs/pull/258)).
 
 ## [0.3.0] 2021-12-08
 

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -103,6 +103,12 @@ macro_rules! libcnb_newtype {
             }
         }
 
+        impl ::std::borrow::Borrow<str> for $name {
+            fn borrow(&self) -> &str {
+                &self.0
+            }
+        }
+
         impl ::std::ops::Deref for $name {
             type Target = String;
 
@@ -201,6 +207,12 @@ mod tests {
 
         let name = "Johanna".parse::<CapitalizedName>().unwrap();
         foo(&name);
+    }
+
+    #[test]
+    fn join() {
+        let names = vec![capitalized_name!("A"), capitalized_name!("B")];
+        assert_eq!("A, B", names.join(", "));
     }
 
     #[test]


### PR DESCRIPTION
This allows the types to be used with `.join()`.

Fixes #182.
GUS-W-10415269.