### PR TITLE
Fix broken docs and add docs linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       run: cargo clippy --all-targets --all-features -- --deny warnings
     - name: rustfmt
       run: cargo fmt -- --check --verbose
+    - name: Check docs
+      # Using RUSTDOCFLAGS until `cargo doc --check` is stabilised:
+      # https://github.com/rust-lang/cargo/issues/10025
+      run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --document-private-items --no-deps
 
   build-and-test:
     runs-on: ubuntu-latest

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -3,13 +3,14 @@
 /// Automatically implements the following traits for the newtype:
 /// - [`Clone`]
 /// - [`Debug`]
-/// - [`Display`]
+/// - [`Display`](std::fmt::Display)
 /// - [`Eq`]
 /// - [`PartialEq`]
 /// - [`serde::Deserialize`]
 /// - [`serde::Serialize`]
-/// - [`FromStr`]
-/// - [`Borrow<String>`]
+/// - [`FromStr`](std::str::FromStr)
+/// - [`Borrow<String>`](std::borrow::Borrow<String>)
+/// - [`Borrow<str>`](std::borrow::Borrow<str>)
 /// - [`Deref<Target=String>`]
 /// - [`AsRef<String>`]
 ///

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -42,7 +42,7 @@ pub trait Buildpack {
     /// collect and send metrics about occurring errors to a central system.
     ///
     /// The default implementation will simply print the error
-    /// (using its [`Display`] implementation) to stderr.
+    /// (using its [`Display`](std::fmt::Display) implementation) to stderr.
     fn handle_error(&self, error: crate::Error<Self::Error>) -> i32 {
         eprintln!("Unhandled error:");
         eprintln!("> {:?}", error);


### PR DESCRIPTION
The Clippy lints already being run in CI check for a few docs related issues, however `rustdoc` has additional lints beyond that:
https://doc.rust-lang.org/rustdoc/lints.html

Several of these lints were reporting warnings when docs are built locally:

```
$ cargo doc --all-features --document-private-items --no-deps
...
warning: unresolved link to `Display`
 --> libcnb-data/src/newtypes.rs:6:9
  |
6 | /// - [`Display`]
  |         ^^^^^^^ no item named `Display` in scope
  |
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `FromStr`
  --> libcnb-data/src/newtypes.rs:11:9
   |
11 | /// - [`FromStr`]
   |         ^^^^^^^ no item named `FromStr` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `Borrow`
  --> libcnb-data/src/newtypes.rs:12:9
   |
12 | /// - [`Borrow<String>`]
   |         ^^^^^^^^^^^^^^ no item named `Borrow` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: `libcnb-data` (lib doc) generated 3 warnings
 Documenting example-01-basics v0.1.0 (/Users/emorley/src/libcnb.rs/examples/example-01-basics)
 Documenting example-02-ruby-sample v0.1.0 (/Users/emorley/src/libcnb.rs/examples/example-02-ruby-sample)
warning: unresolved link to `Display`
  --> libcnb/src/buildpack.rs:45:22
   |
45 |     /// (using its [`Display`] implementation) to stderr.
   |                      ^^^^^^^ no item named `Display` in scope
   |
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: `libcnb` (lib doc) generated 1 warning
```

These have now been fixed, and a docs check added to CI.

See also:
https://doc.rust-lang.org/cargo/commands/cargo-doc.html
https://doc.rust-lang.org/rustdoc/linking-to-items-by-name.html

Fixes #247.
GUS-W-10416368.