### PR TITLE
Enable caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         # Most of the time this will be a no-op, since GitHub releases new images every week
         # which include the latest stable release of Rust, Rustup, Clippy and rustfmt.
         run: rustup update
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Clippy
         # Using --all-targets so tests are checked and --deny to fail on warnings.
         # Not using --locked here and below since Cargo.lock is in .gitignore.
@@ -38,6 +40,8 @@ jobs:
         uses: actions/checkout@v2.4.0
       - name: Update Rust toolchain
         run: rustup update
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Run tests
         run: cargo test --all-features
 
@@ -52,6 +56,8 @@ jobs:
         run: rustup update
       - name: Install Rust linux-musl target
         run: rustup target add x86_64-unknown-linux-musl
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v4.5.0
       - name: Configure Pack CLI


### PR DESCRIPTION
Enables caching using:
https://github.com/Swatinem/rust-cache

This action caches the Cargo index cache, as well as dependencies of libcnb (but nothing else, for cache size efficiency), and automatically handles setting the cache key based on `**/Cargo.toml`, the Rust version and the GitHub job name. See more at:
https://github.com/Swatinem/rust-cache#cache-details

This action is much superior to the manual alternatives I had been investigating prior to finding that action.

This reduces CI end to end time from ~2.5 minutes to ~1 minute.

Fixes #262.
GUS-W-10419238.