### PR TITLE
ProcessBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Modify the project's `src/main.rs` file to contain the following:
 
 ```rust,no_run
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
-use libcnb::data::launch::{Launch, Process};
+use libcnb::data::launch::{Launch, ProcessBuilder};
 use libcnb::data::process_type;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
@@ -152,13 +152,14 @@ impl Buildpack for HelloWorldBuildpack {
         println!("Build runs on stack {}!", context.stack_id);
 
         BuildResultBuilder::new()
-            .launch(Launch::new().process(Process::new(
-                process_type!("web"),
-                "echo",
-                Some(vec!["Hello World!"]),
-                Some(false),
-                Some(true),
-            )))
+            .launch(
+                Launch::new().process(
+                    ProcessBuilder::new(process_type!("web"), "echo")
+                        .arg("Hello World!")
+                        .default(true)
+                        .build(),
+                ),
+            )
             .build()
     }
 }

--- a/examples/example-02-ruby-sample/src/main.rs
+++ b/examples/example-02-ruby-sample/src/main.rs
@@ -1,6 +1,6 @@
 use crate::layers::{BundlerLayer, RubyLayer};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
-use libcnb::data::launch::{Launch, Process};
+use libcnb::data::launch::{Launch, ProcessBuilder};
 use libcnb::data::{layer_name, process_type};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
@@ -44,20 +44,17 @@ impl Buildpack for RubyBuildpack {
         BuildResultBuilder::new()
             .launch(
                 Launch::new()
-                    .process(Process::new(
-                        process_type!("web"),
-                        "bundle",
-                        Some(vec!["exec", "ruby", "app.rb"]),
-                        Some(false),
-                        Some(true),
-                    ))
-                    .process(Process::new(
-                        process_type!("worker"),
-                        "bundle",
-                        Some(vec!["exec", "ruby", "worker.rb"]),
-                        Some(false),
-                        Some(false),
-                    )),
+                    .process(
+                        ProcessBuilder::new(process_type!("web"), "bundle")
+                            .args(vec!["exec", "ruby", "app.rb"])
+                            .default(true)
+                            .build(),
+                    )
+                    .process(
+                        ProcessBuilder::new(process_type!("worker"), "bundle")
+                            .args(vec!["exec", "ruby", "worker.rb"])
+                            .build(),
+                    ),
             )
             .build()
     }

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -10,7 +10,8 @@
 - All libcnb-data struct types now reject unrecognised fields when deserializing ([#252](https://github.com/Malax/libcnb.rs/pull/252)).
 - `BuildpackToml` has been replaced by `BuildpackDescriptor`, which is an enum with `Single` and `Meta` variants that wrap new `SingleBuildpackDescriptor` and `MetaBuildpackDescriptor` types. The new types now reject `buildpack.toml` files where both `stacks` and `order` are present ([#248](https://github.com/Malax/libcnb.rs/pull/248)).
 - Implement `Borrow<str>` for types generated using the `libcnb_newtype!` macro (currently `BuildpackId`, `LayerName`, `ProcessType` and `StackId`), which allows them to be used with `.join()` ([#258](https://github.com/Malax/libcnb.rs/pull/258)).
-- `Process` can now be deserialized when optional fields are missing. ([#265](https://github.com/Malax/libcnb.rs/pull/265))
+- `Launch` and `Process` can now be deserialized when optional fields are missing, and omit default values when serializing ([#243](https://github.com/Malax/libcnb.rs/pull/243) and [#265](https://github.com/Malax/libcnb.rs/pull/265)).
+- `Process::new` has been replaced by `ProcessBuilder` ([#265](https://github.com/Malax/libcnb.rs/pull/265)).
 
 ## [0.3.0] 2021-12-08
 

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -10,7 +10,7 @@
 - All libcnb-data struct types now reject unrecognised fields when deserializing ([#252](https://github.com/Malax/libcnb.rs/pull/252)).
 - `BuildpackToml` has been replaced by `BuildpackDescriptor`, which is an enum with `Single` and `Meta` variants that wrap new `SingleBuildpackDescriptor` and `MetaBuildpackDescriptor` types. The new types now reject `buildpack.toml` files where both `stacks` and `order` are present ([#248](https://github.com/Malax/libcnb.rs/pull/248)).
 - Implement `Borrow<str>` for types generated using the `libcnb_newtype!` macro (currently `BuildpackId`, `LayerName`, `ProcessType` and `StackId`), which allows them to be used with `.join()` ([#258](https://github.com/Malax/libcnb.rs/pull/258)).
-- `Process::args`, `Process::direct`, `Process::default` are now wrapped in `Option` in accordance with the CNB spec ([#243](https://github.com/Malax/libcnb.rs/pull/243)).
+- `Process` can now be deserialized when optional fields are missing. ([#265](https://github.com/Malax/libcnb.rs/pull/265))
 
 ## [0.3.0] 2021-12-08
 

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -23,8 +23,9 @@ pub struct Launch {
 /// use libcnb_data::process_type;
 ///
 /// let mut launch_toml = launch::Launch::new();
-/// let web = launch::Process::new(process_type!("web"), "bundle", Some(vec!["exec", "ruby", "app.rb"]),
-/// Some(false), Some(false));
+/// let web = launch::ProcessBuilder::new(process_type!("web"), "bundle")
+///     .args(vec!["exec", "ruby", "app.rb"])
+///     .build();
 ///
 /// launch_toml.processes.push(web);
 /// assert!(toml::to_string(&launch_toml).is_ok());
@@ -65,29 +66,101 @@ pub struct Label {
 pub struct Process {
     pub r#type: ProcessType,
     pub command: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub args: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub direct: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub default: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub direct: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub default: bool,
 }
 
-impl Process {
-    pub fn new(
-        r#type: ProcessType,
-        command: impl Into<String>,
-        args: Option<impl IntoIterator<Item = impl Into<String>>>,
-        direct: Option<bool>,
-        default: Option<bool>,
-    ) -> Self {
+pub struct ProcessBuilder {
+    process: Process,
+}
+
+/// A non-consuming builder for [`Process`] values.
+///
+/// # Examples
+/// ```
+/// # use libcnb_data::process_type;
+/// # use libcnb_data::launch::ProcessBuilder;
+/// ProcessBuilder::new(process_type!("web"), "java")
+///     .arg("-jar")
+///     .arg("target/application-1.0.0.jar")
+///     .default(true)
+///     .build();
+/// ```
+impl ProcessBuilder {
+    /// Constructs a new `ProcessBuilder` with the following defaults:
+    ///
+    /// * No arguments to the process
+    /// * `direct` is `false`
+    /// * `default` is `false`
+    pub fn new(r#type: ProcessType, command: impl Into<String>) -> Self {
         Self {
-            r#type,
-            command: command.into(),
-            args: args.map(|args| args.into_iter().map(std::convert::Into::into).collect()),
-            direct,
-            default,
+            process: Process {
+                r#type,
+                command: command.into(),
+                args: Vec::new(),
+                direct: false,
+                default: false,
+            },
         }
+    }
+
+    /// Adds an argument to the process.
+    ///
+    /// Only one argument can be passed per use. So instead of:
+    /// ```no_run
+    /// # use libcnb_data::process_type;
+    /// # libcnb_data::launch::ProcessBuilder::new(process_type!("web"), "command")
+    /// .arg("-C /path/to/repo")
+    /// # ;
+    /// ```
+    ///
+    /// usage would be:
+    ///
+    /// ```no_run
+    /// # use libcnb_data::process_type;
+    /// # libcnb_data::launch::ProcessBuilder::new(process_type!("web"), "command")
+    /// .arg("-C")
+    /// .arg("/path/to/repo")
+    /// # ;
+    /// ```
+    ///
+    /// To pass multiple arguments see [`args`](Self::args).
+    pub fn arg(&mut self, arg: impl Into<String>) -> &mut Self {
+        self.process.args.push(arg.into());
+        self
+    }
+
+    /// Adds multiple arguments to pass to the process.
+    ///
+    /// To pass a single argument see [`arg`](Self::arg).
+    pub fn args(&mut self, args: impl IntoIterator<Item = impl Into<String>>) -> &mut Self {
+        for arg in args {
+            self.arg(arg);
+        }
+
+        self
+    }
+
+    /// Sets the direct flag on the process.
+    pub fn direct(&mut self, value: bool) -> &mut Self {
+        self.process.direct = value;
+        self
+    }
+
+    /// Sets the default flag on the process.
+    pub fn default(&mut self, value: bool) -> &mut Self {
+        self.process.default = value;
+        self
+    }
+
+    /// Builds the `Process` based on the configuration of this builder.
+    #[must_use]
+    pub fn build(&self) -> Process {
+        self.process.clone()
     }
 }
 
@@ -166,6 +239,54 @@ mod tests {
         assert_eq!(
             "".parse::<ProcessType>(),
             Err(ProcessTypeError::InvalidValue(String::new()))
+        );
+    }
+
+    #[test]
+    fn process_with_default_values_deserialization() {
+        let toml_str = r#"
+type = "web"
+command = "foo"
+"#;
+
+        assert_eq!(
+            toml::from_str::<Process>(toml_str),
+            Ok(Process {
+                r#type: process_type!("web"),
+                command: String::from("foo"),
+                args: vec![],
+                direct: false,
+                default: false
+            })
+        );
+    }
+
+    #[test]
+    fn process_with_default_values_serialization() {
+        let process = ProcessBuilder::new(process_type!("web"), "foo").build();
+
+        let string = toml::to_string(&process).unwrap();
+        assert_eq!(
+            string,
+            r#"type = "web"
+command = "foo"
+"#
+        );
+    }
+
+    #[test]
+    fn process_with_some_default_values_serialization() {
+        let process = ProcessBuilder::new(process_type!("web"), "foo")
+            .default(true)
+            .build();
+
+        let string = toml::to_string(&process).unwrap();
+        assert_eq!(
+            string,
+            r#"type = "web"
+command = "foo"
+default = true
+"#
         );
     }
 }

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -145,13 +145,18 @@ impl ProcessBuilder {
         self
     }
 
-    /// Sets the direct flag on the process.
+    /// Sets the `direct` flag on the process.
+    ///
+    /// If this is true, the lifecycle will launch the command directly, rather than via a shell.
     pub fn direct(&mut self, value: bool) -> &mut Self {
         self.process.direct = value;
         self
     }
 
-    /// Sets the default flag on the process.
+    /// Sets the `default` flag on the process.
+    ///
+    /// Indicates that the process type should be selected as the buildpack-provided
+    /// default during the export phase.
     pub fn default(&mut self, value: bool) -> &mut Self {
         self.process.default = value;
         self

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -289,4 +289,69 @@ default = true
 "#
         );
     }
+
+    #[test]
+    fn process_builder() {
+        let mut process_builder = ProcessBuilder::new(process_type!("web"), "java");
+
+        assert_eq!(
+            process_builder.build(),
+            Process {
+                r#type: process_type!("web"),
+                command: String::from("java"),
+                args: vec![],
+                direct: false,
+                default: false
+            }
+        );
+
+        process_builder.default(true);
+
+        assert_eq!(
+            process_builder.build(),
+            Process {
+                r#type: process_type!("web"),
+                command: String::from("java"),
+                args: vec![],
+                direct: false,
+                default: true
+            }
+        );
+
+        process_builder.direct(true);
+
+        assert_eq!(
+            process_builder.build(),
+            Process {
+                r#type: process_type!("web"),
+                command: String::from("java"),
+                args: vec![],
+                direct: true,
+                default: true
+            }
+        );
+    }
+
+    #[test]
+    fn process_builder_args() {
+        assert_eq!(
+            ProcessBuilder::new(process_type!("web"), "java")
+                .arg("foo")
+                .args(vec!["baz", "eggs"])
+                .arg("bar")
+                .build(),
+            Process {
+                r#type: process_type!("web"),
+                command: String::from("java"),
+                args: vec![
+                    String::from("foo"),
+                    String::from("baz"),
+                    String::from("eggs"),
+                    String::from("bar"),
+                ],
+                direct: false,
+                default: false
+            }
+        );
+    }
 }

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -135,11 +135,12 @@ pub(crate) enum InnerBuildResult {
 /// use libcnb::build::{BuildResultBuilder, BuildResult};
 /// use libcnb::data::launch::{Launch, Process};
 /// use libcnb::data::process_type;
+/// use libcnb::data::launch::ProcessBuilder;
 ///
 /// let simple: Result<BuildResult, ()> = BuildResultBuilder::new().build();
 ///
 /// let with_launch: Result<BuildResult, ()> = BuildResultBuilder::new()
-///    .launch(Launch::new().process(Process::new(process_type!("type"), "command", Some(vec!["-v"]), Some(false), Some(false))))
+///    .launch(Launch::new().process(ProcessBuilder::new(process_type!("type"), "command").arg("-v").build()))
 ///    .build();
 /// ```
 pub struct BuildResultBuilder {


### PR DESCRIPTION
Adds a `ProcessBuilder` to simplify construction of `Process` values.

In addition, it changes some parts of #243 - `Process` fields are no longer wrapped in `Option` to better match the other types in this crate. This does not change what #243 is fixing: being able to deserialise `Process` values where some optional fields are missing. I also added tests for this.

GUS-W-10422974