### PR TITLE
Rename `Buildpack::handle_error` to `Buildpack::on_error`

### DIFF
--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/Malax/libcnb.rs/pull/232)).
 - `TargetLifecycle` has been renamed to `Scope` ([#257](https://github.com/Malax/libcnb.rs/pull/257)).
+- Renamed `Buildpack::handle_error` to `Buildpack::on_error` to make it clearer that the error cannot be handled/resolved, just reacted upon ([#266](https://github.com/Malax/libcnb.rs/pull/266)).
 
 ## [0.4.0] 2021-12-08
 

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -35,15 +35,15 @@ pub trait Buildpack {
     fn build(&self, context: BuildContext<Self>) -> crate::Result<BuildResult, Self::Error>;
 
     /// If an unhandled error occurred within the framework or the buildpack, this method will be
-    /// called by the framework to allow custom, buildpack specific, error handling. Usually,
-    /// this method is implemented by logging the error in a user friendly manner.
+    /// called by the framework to allow custom, buildpack specific, code to run before exiting.
+    /// Usually, this method is implemented by logging the error in a user friendly manner.
     ///
     /// Implementations are not limited to just logging, for example, buildpacks might want to
     /// collect and send metrics about occurring errors to a central system.
     ///
     /// The default implementation will simply print the error
     /// (using its [`Display`](std::fmt::Display) implementation) to stderr.
-    fn handle_error(&self, error: crate::Error<Self::Error>) -> i32 {
+    fn on_error(&self, error: crate::Error<Self::Error>) -> i32 {
         eprintln!("Unhandled error:");
         eprintln!("> {:?}", error);
         eprintln!("Buildpack will exit!");

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -47,7 +47,7 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
             }
         }
         Err(lib_cnb_error) => {
-            exit(buildpack.handle_error(lib_cnb_error));
+            exit(buildpack.on_error(lib_cnb_error));
         }
     }
 
@@ -77,7 +77,7 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
     };
 
     if let Err(lib_cnb_error) = result {
-        exit(buildpack.handle_error(lib_cnb_error));
+        exit(buildpack.on_error(lib_cnb_error));
     }
 }
 


### PR DESCRIPTION
Renamed `Buildpack::handle_error` to `Buildpack::on_error` to make clearer that the error cannot be handled/resolved, just reacted upon. The method is otherwise unchanged.

GUS-W-10423774