### PR TITLE
Add LayerEnv::apply_to_empty

### DIFF
--- a/examples/example-02-ruby-sample/src/main.rs
+++ b/examples/example-02-ruby-sample/src/main.rs
@@ -5,7 +5,7 @@ use libcnb::data::{layer_name, process_type};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
 use libcnb::layer_env::Scope;
-use libcnb::{buildpack_main, Buildpack, Env};
+use libcnb::{buildpack_main, Buildpack};
 
 use crate::util::{DownloadError, UntarError};
 use serde::Deserialize;
@@ -37,7 +37,7 @@ impl Buildpack for RubyBuildpack {
         context.handle_layer(
             layer_name!("bundler"),
             BundlerLayer {
-                ruby_env: ruby_layer.env.apply(Scope::Build, &Env::new()),
+                ruby_env: ruby_layer.env.apply_to_empty(Scope::Build),
             },
         )?;
 

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/Malax/libcnb.rs/pull/232)).
 - `TargetLifecycle` has been renamed to `Scope` ([#257](https://github.com/Malax/libcnb.rs/pull/257)).
 - Renamed `Buildpack::handle_error` to `Buildpack::on_error` to make it clearer that the error cannot be handled/resolved, just reacted upon ([#266](https://github.com/Malax/libcnb.rs/pull/266)).
+- Add `LayerEnv::apply_to_empty` ([#267](https://github.com/Malax/libcnb.rs/pull/267)).
 
 ## [0.4.0] 2021-12-08
 

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -299,7 +299,7 @@ mod tests {
     use crate::data::layer_name;
     use crate::generic::GenericMetadata;
     use crate::layer_env::{ModificationBehavior, Scope};
-    use crate::{read_toml_file, Env};
+    use crate::read_toml_file;
     use serde::Deserialize;
     use std::ffi::OsString;
     use std::fs;
@@ -557,7 +557,7 @@ mod tests {
             }
         );
 
-        let applied_layer_env = layer_data.env.apply(Scope::Build, &Env::new());
+        let applied_layer_env = layer_data.env.apply_to_empty(Scope::Build);
         assert_eq!(
             applied_layer_env.get("PATH"),
             Some(layer_dir.join("bin").into())

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -165,6 +165,14 @@ impl LayerEnv {
             .fold(env.clone(), |env, delta| delta.apply(&env))
     }
 
+    /// Applies this [`LayerEnv`] to an empty [`Env`] for the given [`Scope`].
+    ///
+    /// For applying to an existing [`Env`], see [apply](Self::apply).
+    #[must_use]
+    pub fn apply_to_empty(&self, scope: Scope) -> Env {
+        self.apply(scope, &Env::new())
+    }
+
     /// Insert a new entry into this `LayerEnv`.
     ///
     /// Should there already be an entry for the same scope, modification behavior and

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -75,12 +75,10 @@ use crate::Env;
 /// fs::create_dir_all(layer_dir.join("include")).unwrap();
 ///
 /// let layer_env = LayerEnv::read_from_layer_dir(&layer_dir).unwrap();
+/// let env = layer_env.apply_to_empty(Scope::Launch);
 ///
-/// let env = Env::new();
-/// let modified_env = layer_env.apply(Scope::Launch, &env);
-///
-/// assert_eq!(modified_env.get("PATH").unwrap(), layer_dir.join("bin"));
-/// assert_eq!(modified_env.get("CPATH"), None); // None, because CPATH is only added during build
+/// assert_eq!(env.get("PATH").unwrap(), layer_dir.join("bin"));
+/// assert_eq!(env.get("CPATH"), None); // None, because CPATH is only added during build
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct LayerEnv {
@@ -189,11 +187,10 @@ impl LayerEnv {
     /// layer_env.insert(Scope::All, ModificationBehavior::Append, "VAR2", "foo");
     /// layer_env.insert(Scope::All, ModificationBehavior::Append, "VAR2", "bar");
     ///
-    /// let mut env = Env::new();
-    /// let modified_env = layer_env.apply(Scope::Build, &env);
+    /// let env = layer_env.apply_to_empty(Scope::Build);
     ///
-    /// assert_eq!(modified_env.get("VAR").unwrap(), "hello");
-    /// assert_eq!(modified_env.get("VAR2").unwrap(), "bar");
+    /// assert_eq!(env.get("VAR").unwrap(), "hello");
+    /// assert_eq!(env.get("VAR2").unwrap(), "bar");
     /// ```
     ///
     /// See [`LayerEnv::chainable_insert`] that allows easy creation of inline `LayerEnv` values
@@ -229,10 +226,9 @@ impl LayerEnv {
     /// use libcnb::Env;
     ///
     /// fn something_that_needs_layer_env(layer_env: LayerEnv) {
-    ///     let mut env = Env::new();
-    ///     let modified_env = layer_env.apply(Scope::Build, &env);
-    ///     assert_eq!(modified_env.get("VAR").unwrap(), "hello");
-    ///     assert_eq!(modified_env.get("VAR2").unwrap(), "bar");
+    ///     let env = layer_env.apply_to_empty(Scope::Build);
+    ///     assert_eq!(env.get("VAR").unwrap(), "hello");
+    ///     assert_eq!(env.get("VAR2").unwrap(), "bar");
     /// }
     ///
     /// something_that_needs_layer_env(
@@ -288,12 +284,10 @@ impl LayerEnv {
     /// fs::write(layer_env_dir.join("ZERO_WING.default"), "ALL_YOUR_BASE_ARE_BELONG_TO_US").unwrap();
     ///
     /// let layer_env = LayerEnv::read_from_layer_dir(&layer_dir).unwrap();
+    /// let env = layer_env.apply_to_empty(Scope::Launch);
     ///
-    /// let env = Env::new();
-    /// let modified_env = layer_env.apply(Scope::Launch, &env);
-    ///
-    /// assert_eq!(modified_env.get("PATH").unwrap(), layer_dir.join("bin"));
-    /// assert_eq!(modified_env.get("ZERO_WING").unwrap(), "ALL_YOUR_BASE_ARE_BELONG_TO_US");
+    /// assert_eq!(env.get("PATH").unwrap(), layer_dir.join("bin"));
+    /// assert_eq!(env.get("ZERO_WING").unwrap(), "ALL_YOUR_BASE_ARE_BELONG_TO_US");
     /// ```
     pub fn read_from_layer_dir(layer_dir: impl AsRef<Path>) -> Result<Self, std::io::Error> {
         let mut result_layer_env = Self::new();
@@ -812,7 +806,7 @@ mod tests {
             "-XX:+UseSerialGC",
         );
 
-        let result_env = layer_env.apply(Scope::Build, &Env::new());
+        let result_env = layer_env.apply_to_empty(Scope::Build);
         assert_eq!(
             vec![
                 ("JAVA_TOOL_OPTIONS", "-Xmx2G"),
@@ -884,17 +878,13 @@ mod tests {
         fs::create_dir_all(layer_dir.join("pkgconfig")).unwrap();
 
         let layer_env = LayerEnv::read_from_layer_dir(&layer_dir).unwrap();
-        let env = Env::new();
 
-        let modified_env = layer_env.apply(Scope::Launch, &env);
-        assert_eq!(modified_env.get("PATH").unwrap(), layer_dir.join("bin"));
-        assert_eq!(
-            modified_env.get("LD_LIBRARY_PATH").unwrap(),
-            layer_dir.join("lib")
-        );
-        assert_eq!(modified_env.get("LIBRARY_PATH"), None);
-        assert_eq!(modified_env.get("CPATH"), None);
-        assert_eq!(modified_env.get("PKG_CONFIG_PATH"), None);
+        let env = layer_env.apply_to_empty(Scope::Launch);
+        assert_eq!(env.get("PATH").unwrap(), layer_dir.join("bin"));
+        assert_eq!(env.get("LD_LIBRARY_PATH").unwrap(), layer_dir.join("lib"));
+        assert_eq!(env.get("LIBRARY_PATH"), None);
+        assert_eq!(env.get("CPATH"), None);
+        assert_eq!(env.get("PKG_CONFIG_PATH"), None);
     }
 
     #[test]
@@ -909,24 +899,14 @@ mod tests {
         fs::create_dir_all(layer_dir.join("pkgconfig")).unwrap();
 
         let layer_env = LayerEnv::read_from_layer_dir(&layer_dir).unwrap();
-        let env = Env::new();
 
-        let modified_env = layer_env.apply(Scope::Build, &env);
-        assert_eq!(modified_env.get("PATH").unwrap(), layer_dir.join("bin"));
+        let env = layer_env.apply_to_empty(Scope::Build);
+        assert_eq!(env.get("PATH").unwrap(), layer_dir.join("bin"));
+        assert_eq!(env.get("LD_LIBRARY_PATH").unwrap(), layer_dir.join("lib"));
+        assert_eq!(env.get("LIBRARY_PATH").unwrap(), layer_dir.join("lib"));
+        assert_eq!(env.get("CPATH").unwrap(), layer_dir.join("include"));
         assert_eq!(
-            modified_env.get("LD_LIBRARY_PATH").unwrap(),
-            layer_dir.join("lib")
-        );
-        assert_eq!(
-            modified_env.get("LIBRARY_PATH").unwrap(),
-            layer_dir.join("lib")
-        );
-        assert_eq!(
-            modified_env.get("CPATH").unwrap(),
-            layer_dir.join("include")
-        );
-        assert_eq!(
-            modified_env.get("PKG_CONFIG_PATH").unwrap(),
+            env.get("PKG_CONFIG_PATH").unwrap(),
             layer_dir.join("pkgconfig")
         );
     }

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -125,6 +125,8 @@ impl LayerEnv {
 
     /// Applies this [`LayerEnv`] to the given [`Env`] for the given [`Scope`].
     ///
+    /// For applying to an empty [`Env`], see [`apply_to_empty`](Self::apply_to_empty).
+    ///
     /// # Example:
     ///```
     /// use libcnb::layer_env::{LayerEnv, Scope, ModificationBehavior};
@@ -165,7 +167,7 @@ impl LayerEnv {
 
     /// Applies this [`LayerEnv`] to an empty [`Env`] for the given [`Scope`].
     ///
-    /// For applying to an existing [`Env`], see [apply](Self::apply).
+    /// For applying to an existing [`Env`], see [`apply`](Self::apply).
     #[must_use]
     pub fn apply_to_empty(&self, scope: Scope) -> Env {
         self.apply(scope, &Env::new())


### PR DESCRIPTION
It's a common pattern to apply a layer env and pass the resulting env to another layer. like so:

```rust
ruby_layer.env.apply(Scope::Build, &Env::new())
```

However, they're mostly applied to an empty env which is a little bit clunky. As a QOL enhancement, add `LayerEnv::apply_to_empty` which removes the second argument:

```rust
ruby_layer.env.apply_to_empty(Scope::Build)
```

GUS-W-10423858