### PR TITLE
Combine two adjacent `impl BuildResultBuilder` blocks

### DIFF
--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -155,9 +155,7 @@ impl BuildResultBuilder {
             store: None,
         }
     }
-}
 
-impl BuildResultBuilder {
     /// Builds the final [`BuildResult`].
     ///
     /// This method returns the [`BuildResult`] wrapped in a [`Result`] even though its technically


### PR DESCRIPTION
There's no need to have these as separate blocks, presume it was unintentionally added in #135.