### PR TITLE
Bump external dependency versions

### DIFF
--- a/examples/example-01-basics/Cargo.toml
+++ b/examples/example-01-basics/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-"libcnb" = { path = "../../libcnb" }
+libcnb = { path = "../../libcnb" }

--- a/examples/example-02-ruby-sample/Cargo.toml
+++ b/examples/example-02-ruby-sample/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-flate2 = "1"
-ureq = "2.2.1"
-sha2 = "0.10"
-tar = "0.4"
-toml = "0.5"
-tempfile = "3"
-"libcnb" = { path = "../../libcnb" }
-serde = "1.0.126"
+flate2 = "1.0.22"
+libcnb = { path = "../../libcnb" }
+serde = "1.0.133"
+sha2 = "0.10.1"
+tar = "0.4.38"
+tempfile = "3.3.0"
+toml = "0.5.8"
+ureq = "2.4.0"

--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - `BuildpackData`, `assemble_buildpack_directory()` and `default_buildpack_directory_name()` have been updated for the libcnb-data replacement of `BuildpackToml` with `*BuildpackDescriptor` and rename of `*buildpack_toml` to `*buildpack_descriptor` ([#248](https://github.com/Malax/libcnb.rs/pull/248) and [#254](https://github.com/Malax/libcnb.rs/pull/254)).
+- Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233)).
 
 ## [0.1.0] 2021-12-08
 

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Implement `Borrow<str>` for types generated using the `libcnb_newtype!` macro (currently `BuildpackId`, `LayerName`, `ProcessType` and `StackId`), which allows them to be used with `.join()` ([#258](https://github.com/Malax/libcnb.rs/pull/258)).
 - `Launch` and `Process` can now be deserialized when optional fields are missing, and omit default values when serializing ([#243](https://github.com/Malax/libcnb.rs/pull/243) and [#265](https://github.com/Malax/libcnb.rs/pull/265)).
 - `Process::new` has been replaced by `ProcessBuilder` ([#265](https://github.com/Malax/libcnb.rs/pull/265)).
+- Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233) and [#275](https://github.com/Malax/libcnb.rs/pull/275)).
 
 ## [0.3.0] 2021-12-08
 

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -13,9 +13,9 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 [dependencies]
 fancy-regex = "0.7.1"
 libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.1.0" }
-serde = { version = "1.0.130", features = ["derive"] }
+serde = { version = "1.0.133", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"
 
 [dev-dependencies]
-serde_test = "1.0.130"
+serde_test = "1.0.133"

--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233) and [#275](https://github.com/Malax/libcnb.rs/pull/275)).
+
 ## [0.1.0] 2021-12-08
 
 - Add a `verify_regex!` macro for compile-time string validation ([#172](https://github.com/Malax/libcnb.rs/pull/172)).

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -14,5 +14,5 @@ proc-macro = true
 
 [dependencies]
 fancy-regex = "0.7.1"
-quote = "1.0.10"
-syn = { version = "1.0.82", features = ["full"] }
+quote = "1.0.14"
+syn = { version = "1.0.85", features = ["full"] }

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `TargetLifecycle` has been renamed to `Scope` ([#257](https://github.com/Malax/libcnb.rs/pull/257)).
 - Renamed `Buildpack::handle_error` to `Buildpack::on_error` to make it clearer that the error cannot be handled/resolved, just reacted upon ([#266](https://github.com/Malax/libcnb.rs/pull/266)).
 - Add `LayerEnv::apply_to_empty` ([#267](https://github.com/Malax/libcnb.rs/pull/267)).
+- Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233) and [#275](https://github.com/Malax/libcnb.rs/pull/275)).
 
 ## [0.4.0] 2021-12-08
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -11,12 +11,12 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
-anyhow = { version = "1.0.51", optional = true }
+anyhow = { version = "1.0.52", optional = true }
 libcnb-data = { path = "../libcnb-data", version = "0.3.0" }
-serde = { version = "1.0.130", features = ["derive"] }
+serde = { version = "1.0.133", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"
 
 [dev-dependencies]
 rand = "0.8.4"
-tempfile = "3.2.0"
+tempfile = "3.3.0"


### PR DESCRIPTION
* Bumps minor/patch versions (a no-op for new installs given library so no lock file, but bumps deps for developing locally where `Cargo.lock` is `.gitignore`d and so goes stale, or for existing installs where people don't have Dependabot updating their other deps).
* Makes the `example-02-ruby-sample` dependency list consistent with the other crates (sort alphabetically + use full version specifiers).
* Removes redundant quotes around the `libcnb` dependency in both examples.