### PR TITLE
Bump crate versions for libcnb 0.5.0 release

### DIFF
--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## [Unreleased]
 
+## [0.2.0] 2022-01-14
+
 - `BuildpackData`, `assemble_buildpack_directory()` and `default_buildpack_directory_name()` have been updated for the libcnb-data replacement of `BuildpackToml` with `*BuildpackDescriptor` and rename of `*buildpack_toml` to `*buildpack_descriptor` ([#248](https://github.com/Malax/libcnb.rs/pull/248) and [#254](https://github.com/Malax/libcnb.rs/pull/254)).
 - Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233)).
+- Update `libcnb-data` from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#040-2022-01-14) ([#276](https://github.com/Malax/libcnb.rs/pull/276)).
 
 ## [0.1.0] 2021-12-08
 

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-cargo"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.56"
 license = "BSD-3-Clause"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 cargo_metadata = "0.14.1"
 clap = "2.34.0"
 fs_extra = "1.2.0"
-libcnb-data = { version = "0.3.0", path = "../libcnb-data" }
+libcnb-data = { version = "0.4.0", path = "../libcnb-data" }
 log = "0.4.14"
 pathdiff = "0.2.1"
 size_format = "1.0.2"

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.0] 2022-01-14
+
 - Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/Malax/libcnb.rs/pull/232)).
 - Remove builder-style methods from `LayerContentMetadata` ([#235](https://github.com/Malax/libcnb.rs/pull/235)).
 - Make `LayerContentMetadata`'s `types` field an `Option` ([#236](https://github.com/Malax/libcnb.rs/pull/236)).
@@ -13,6 +15,7 @@
 - `Launch` and `Process` can now be deserialized when optional fields are missing, and omit default values when serializing ([#243](https://github.com/Malax/libcnb.rs/pull/243) and [#265](https://github.com/Malax/libcnb.rs/pull/265)).
 - `Process::new` has been replaced by `ProcessBuilder` ([#265](https://github.com/Malax/libcnb.rs/pull/265)).
 - Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233) and [#275](https://github.com/Malax/libcnb.rs/pull/275)).
+- Update `libcnb-proc-macros` from `0.1.0` to `0.1.1` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#011-2022-01-14) ([#276](https://github.com/Malax/libcnb.rs/pull/276)).
 
 ## [0.3.0] 2021-12-08
 

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-data"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.56"
 license = "BSD-3-Clause"
@@ -12,7 +12,7 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
 fancy-regex = "0.7.1"
-libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.1.0" }
+libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.1.1" }
 serde = { version = "1.0.133", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"

--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.1.1] 2022-01-14
+
 - Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233) and [#275](https://github.com/Malax/libcnb.rs/pull/275)).
 
 ## [0.1.0] 2021-12-08

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-proc-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.56"
 license = "BSD-3-Clause"

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## [Unreleased]
 
+## [0.5.0] 2022-01-14
+
 - Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/Malax/libcnb.rs/pull/232)).
 - `TargetLifecycle` has been renamed to `Scope` ([#257](https://github.com/Malax/libcnb.rs/pull/257)).
 - Renamed `Buildpack::handle_error` to `Buildpack::on_error` to make it clearer that the error cannot be handled/resolved, just reacted upon ([#266](https://github.com/Malax/libcnb.rs/pull/266)).
 - Add `LayerEnv::apply_to_empty` ([#267](https://github.com/Malax/libcnb.rs/pull/267)).
 - Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233) and [#275](https://github.com/Malax/libcnb.rs/pull/275)).
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#040-2022-01-14) ([#276](https://github.com/Malax/libcnb.rs/pull/276)).
 
 ## [0.4.0] 2021-12-08
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.56"
 license = "BSD-3-Clause"
@@ -12,7 +12,7 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
 anyhow = { version = "1.0.52", optional = true }
-libcnb-data = { path = "../libcnb-data", version = "0.3.0" }
+libcnb-data = { path = "../libcnb-data", version = "0.4.0" }
 serde = { version = "1.0.133", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"


### PR DESCRIPTION
After this is merged, I will publish the following crates (in this order):
- `libcnb-proc-macros`
- `libcnb-data`
- `libcnb-cargo`
- `libcnb`

Closes #273.
GUS-W-10409467.