### PR TITLE
Allow for multiple non-bin targets

### DIFF
--- a/libcnb-cargo/src/main.rs
+++ b/libcnb-cargo/src/main.rs
@@ -155,11 +155,11 @@ fn handle_libcnb_package(matches: &ArgMatches) {
                     );
                     error!("Examine Cargo output for details and potential compilation errors.");
                 }
-                BuildError::NoTargetsFound => {
-                    error!("No targets were found in the Cargo manifest. Ensure that there is exactly one binary target and try again.");
+                BuildError::NoBinTargetsFound => {
+                    error!("No binary targets were found in the Cargo manifest. Ensure that there is exactly one binary target and try again.");
                 }
-                BuildError::MultipleTargetsFound => {
-                    error!("Multiple targets were found in the Cargo manifest. Ensure that there is exactly one binary target and try again.");
+                BuildError::MultipleBinTargetsFound => {
+                    error!("Multiple binary targets were found in the Cargo manifest. Ensure that there is exactly one binary target and try again.");
                 }
                 BuildError::MetadataError(metadata_error) => {
                     error!("Unable to obtain metadata from Cargo: {}", metadata_error);


### PR DESCRIPTION
Currently `libcnb-cargo` allows exactly one target in the buildpack crate. When a crate uses integration tests, these will be an additional target, causing `cargo libcnb package` to always fail for buildpacks with integration tests.

To work around this, `libcnb-cargo` now only checks if there is a single _binary_ target.

GUS-W-10449039, extracted from #277 