### PR TITLE
Update buildpack assembly to no longer fail on existing output directories

### DIFF
--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - `cargo libcnb package` now allows multiple targets, as long as there is only one binary target. To support this change, the `BuildError` variants `NoTargetsFound` and `MultipleTargetsFound` have been replaced by `NoBinTargetsFound` and `MultipleBinTargetsFound` respectively. ([#282](https://github.com/Malax/libcnb.rs/pull/282))
+- `assemble_buildpack_directory()` no longer fails if then output directory already exists. ([#283](https://github.com/Malax/libcnb.rs/pull/283))
 
 ## [0.2.0] 2022-01-14
 

--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - `cargo libcnb package` now allows multiple targets, as long as there is only one binary target. To support this change, the `BuildError` variants `NoTargetsFound` and `MultipleTargetsFound` have been replaced by `NoBinTargetsFound` and `MultipleBinTargetsFound` respectively. ([#282](https://github.com/Malax/libcnb.rs/pull/282))
-- `assemble_buildpack_directory()` no longer fails if then output directory already exists. ([#283](https://github.com/Malax/libcnb.rs/pull/283))
+- `assemble_buildpack_directory()` no longer fails if the output directory already exists. ([#283](https://github.com/Malax/libcnb.rs/pull/283))
 
 ## [0.2.0] 2022-01-14
 

--- a/libcnb-cargo/src/lib.rs
+++ b/libcnb-cargo/src/lib.rs
@@ -9,7 +9,6 @@ use cargo_metadata::{MetadataCommand, Target};
 use libcnb_data::buildpack::SingleBuildpackDescriptor;
 use std::ffi::OsStr;
 use std::fs;
-use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 
@@ -159,33 +158,26 @@ pub struct BuildpackData<BM> {
 ///
 /// # Errors
 ///
-/// Will return `Err` if the buildpack directory already exists or could not be assembled.
+/// Will return `Err` if the buildpack directory could not be assembled.
 pub fn assemble_buildpack_directory(
     destination_path: impl AsRef<Path>,
     buildpack_descriptor_path: impl AsRef<Path>,
     buildpack_binary_path: impl AsRef<Path>,
 ) -> std::io::Result<()> {
-    if destination_path.as_ref().exists() {
-        Err(io::Error::new(
-            io::ErrorKind::AlreadyExists,
-            "Destination path already exists!",
-        ))
-    } else {
-        fs::create_dir_all(destination_path.as_ref())?;
+    fs::create_dir_all(destination_path.as_ref())?;
 
-        fs::copy(
-            buildpack_descriptor_path.as_ref(),
-            destination_path.as_ref().join("buildpack.toml"),
-        )?;
+    fs::copy(
+        buildpack_descriptor_path.as_ref(),
+        destination_path.as_ref().join("buildpack.toml"),
+    )?;
 
-        let bin_path = destination_path.as_ref().join("bin");
-        fs::create_dir_all(&bin_path)?;
+    let bin_path = destination_path.as_ref().join("bin");
+    fs::create_dir_all(&bin_path)?;
 
-        fs::copy(buildpack_binary_path.as_ref(), bin_path.join("build"))?;
-        create_file_symlink("build", bin_path.join("detect"))?;
+    fs::copy(buildpack_binary_path.as_ref(), bin_path.join("build"))?;
+    create_file_symlink("build", bin_path.join("detect"))?;
 
-        Ok(())
-    }
+    Ok(())
 }
 
 #[cfg(target_family = "unix")]


### PR DESCRIPTION
This is a remnant from when existing output directories always failed. For CLI usage, the directory is always removed before calling `assemble_buildpack_directory`. Therefore, this PR changes nothing for CLI usage.

This change was originally made for #277 to allow buildpack directory assembly into a `tempdir::TempDir` which will always exist when `assemble_buildpack_directory` is called.

Closes GUS-W-10449107