### PR TITLE
Fix Clippy warnings seen with Rust 1.59 beta

### DIFF
--- a/libcnb-cargo/src/lib.rs
+++ b/libcnb-cargo/src/lib.rs
@@ -203,5 +203,5 @@ fn create_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
 pub fn default_buildpack_directory_name<BM>(
     buildpack_descriptor: &SingleBuildpackDescriptor<BM>,
 ) -> String {
-    buildpack_descriptor.buildpack.id.replace("/", "_")
+    buildpack_descriptor.buildpack.id.replace('/', "_")
 }

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add `#[must_use]` to `BuildPlanBuilder::provides` and `BuildPlanBuilder::requires` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
+
 ## [0.4.0] 2022-01-14
 
 - Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/Malax/libcnb.rs/pull/232)).

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Add `#[must_use]` to `BuildPlanBuilder::provides` and `BuildPlanBuilder::requires` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
+- Add `#[must_use]` to `BuildPlan` and `BuildPlanBuilder` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
 
 ## [0.4.0] 2022-01-14
 

--- a/libcnb-data/src/build_plan.rs
+++ b/libcnb-data/src/build_plan.rs
@@ -45,11 +45,13 @@ impl BuildPlanBuilder {
         }
     }
 
+    #[must_use]
     pub fn provides(mut self, name: impl AsRef<str>) -> Self {
         self.current_provides.push(Provide::new(name.as_ref()));
         self
     }
 
+    #[must_use]
     pub fn requires(mut self, name: impl AsRef<str>) -> Self {
         self.current_requires.push(Require::new(name.as_ref()));
         self

--- a/libcnb-data/src/build_plan.rs
+++ b/libcnb-data/src/build_plan.rs
@@ -3,6 +3,7 @@ use std::collections::VecDeque;
 use toml::value::Table;
 
 #[derive(Serialize, Debug)]
+#[must_use]
 pub struct BuildPlan {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub provides: Vec<Provide>,
@@ -13,7 +14,6 @@ pub struct BuildPlan {
 }
 
 impl BuildPlan {
-    #[must_use]
     pub fn new() -> Self {
         Self {
             provides: vec![],
@@ -29,6 +29,7 @@ impl Default for BuildPlan {
     }
 }
 
+#[must_use]
 pub struct BuildPlanBuilder {
     acc: VecDeque<(Vec<Provide>, Vec<Require>)>,
     current_provides: Vec<Provide>,
@@ -36,7 +37,6 @@ pub struct BuildPlanBuilder {
 }
 
 impl BuildPlanBuilder {
-    #[must_use]
     pub fn new() -> Self {
         Self {
             acc: VecDeque::new(),
@@ -45,19 +45,16 @@ impl BuildPlanBuilder {
         }
     }
 
-    #[must_use]
     pub fn provides(mut self, name: impl AsRef<str>) -> Self {
         self.current_provides.push(Provide::new(name.as_ref()));
         self
     }
 
-    #[must_use]
     pub fn requires(mut self, name: impl AsRef<str>) -> Self {
         self.current_requires.push(Require::new(name.as_ref()));
         self
     }
 
-    #[must_use]
     pub fn or(mut self) -> Self {
         self.acc
             .push_back((self.current_provides, self.current_requires));
@@ -67,7 +64,6 @@ impl BuildPlanBuilder {
         self
     }
 
-    #[must_use]
     pub fn build(self) -> BuildPlan {
         let mut xyz = self.or();
 

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add `#[must_use]` to `DetectResult`, `DetectResultBuilder`, `PassDetectResultBuilder`, `FailDetectResultBuilder`, `BuildResult` and `BuildResultBuilder` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
+
 ## [0.5.0] 2022-01-14
 
 - Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/Malax/libcnb.rs/pull/232)).

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -118,6 +118,7 @@ impl<B: Buildpack + ?Sized> BuildContext<B> {
 ///
 /// To construct values of this type, use a [`BuildResultBuilder`].
 #[derive(Debug)]
+#[must_use]
 pub struct BuildResult(pub(crate) InnerBuildResult);
 
 #[derive(Debug)]
@@ -143,13 +144,13 @@ pub(crate) enum InnerBuildResult {
 ///    .launch(Launch::new().process(ProcessBuilder::new(process_type!("type"), "command").arg("-v").build()))
 ///    .build();
 /// ```
+#[must_use]
 pub struct BuildResultBuilder {
     launch: Option<Launch>,
     store: Option<Store>,
 }
 
 impl BuildResultBuilder {
-    #[must_use]
     pub fn new() -> Self {
         Self {
             launch: None,
@@ -168,7 +169,6 @@ impl BuildResultBuilder {
         Ok(self.build_unwrapped())
     }
 
-    #[must_use]
     pub fn build_unwrapped(self) -> BuildResult {
         BuildResult(InnerBuildResult::Pass {
             launch: self.launch,
@@ -176,13 +176,11 @@ impl BuildResultBuilder {
         })
     }
 
-    #[must_use]
     pub fn launch(mut self, launch: Launch) -> Self {
         self.launch = Some(launch);
         self
     }
 
-    #[must_use]
     pub fn store(mut self, store: Store) -> Self {
         self.store = Some(store);
         self

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -21,6 +21,7 @@ pub struct DetectContext<B: Buildpack + ?Sized> {
 /// Besides indicating passing or failing detection, it also contains detect phase output such as
 /// the build plan. To construct values of this type, use a [`DetectResultBuilder`].
 #[derive(Debug)]
+#[must_use]
 pub struct DetectResult(pub(crate) InnerDetectResult);
 
 #[derive(Debug)]
@@ -43,15 +44,14 @@ pub(crate) enum InnerDetectResult {
 ///    .build_plan(BuildPlanBuilder::new().provides("something").build())
 ///    .build();
 /// ```
+#[must_use]
 pub struct DetectResultBuilder;
 
 impl DetectResultBuilder {
-    #[must_use]
     pub fn pass() -> PassDetectResultBuilder {
         PassDetectResultBuilder { build_plan: None }
     }
 
-    #[must_use]
     pub fn fail() -> FailDetectResultBuilder {
         FailDetectResultBuilder {}
     }
@@ -59,6 +59,7 @@ impl DetectResultBuilder {
 
 /// Constructs [`DetectResult`] values for a passed detection. Can't be used directly, use
 /// a [`DetectResultBuilder`] to create an instance.
+#[must_use]
 pub struct PassDetectResultBuilder {
     build_plan: Option<BuildPlan>,
 }
@@ -75,14 +76,12 @@ impl PassDetectResultBuilder {
         Ok(self.build_unwrapped())
     }
 
-    #[must_use]
     pub fn build_unwrapped(self) -> DetectResult {
         DetectResult(InnerDetectResult::Pass {
             build_plan: self.build_plan,
         })
     }
 
-    #[must_use]
     pub fn build_plan(mut self, build_plan: BuildPlan) -> Self {
         self.build_plan = Some(build_plan);
         self
@@ -91,6 +90,7 @@ impl PassDetectResultBuilder {
 
 /// Constructs [`DetectResult`] values for a failed detection. Can't be used directly, use
 /// a [`DetectResultBuilder`] to create an instance.
+#[must_use]
 pub struct FailDetectResultBuilder;
 
 impl FailDetectResultBuilder {
@@ -106,7 +106,6 @@ impl FailDetectResultBuilder {
     }
 
     #[allow(clippy::unused_self)]
-    #[must_use]
     pub fn build_unwrapped(self) -> DetectResult {
         DetectResult(InnerDetectResult::Fail)
     }


### PR DESCRIPTION
New Rust versions come with new Clippy versions, that can add new lints or adjust existing lints.

Locally I'm running Rust 1.59 beta, and it reports a few new Clippy warnings, that this PR resolves:

```
warning: missing `#[must_use]` attribute on a method returning `Self`
  --> libcnb-data/src/build_plan.rs:48:5
   |
48 | /     pub fn provides(mut self, name: impl AsRef<str>) -> Self {
49 | |         self.current_provides.push(Provide::new(name.as_ref()));
50 | |         self
51 | |     }
   | |_____^
   |
   = note: `#[warn(clippy::return_self_not_must_use)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use

warning: missing `#[must_use]` attribute on a method returning `Self`
  --> libcnb-data/src/build_plan.rs:53:5
   |
53 | /     pub fn requires(mut self, name: impl AsRef<str>) -> Self {
54 | |         self.current_requires.push(Require::new(name.as_ref()));
55 | |         self
56 | |     }
   | |_____^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use

warning: `libcnb-data` (lib) generated 2 warnings
warning: single-character string constant used as pattern
   --> libcnb-cargo/src/lib.rs:206:47
    |
206 |     buildpack_descriptor.buildpack.id.replace("/", "_")
    |                                               ^^^ help: try using a `char` instead: `'/'`
    |
    = note: `#[warn(clippy::single_char_pattern)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern
```

GUS-W-10473558.