### PR TITLE
Switch from `rand` to `fastrand` in libcnb layer tests

### DIFF
--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -18,5 +18,5 @@ thiserror = "1.0.30"
 toml = "0.5.8"
 
 [dev-dependencies]
-rand = "0.8.4"
+fastrand = "1.7.0"
 tempfile = "3.3.0"

--- a/libcnb/src/layer/test.rs
+++ b/libcnb/src/layer/test.rs
@@ -25,10 +25,10 @@ use libcnb_data::buildpack::{BuildpackVersion, SingleBuildpackDescriptor, Stack}
 use libcnb_data::buildpack_plan::BuildpackPlan;
 use libcnb_data::layer::LayerName;
 use libcnb_data::layer_content_metadata::LayerContentMetadata;
-use rand::Rng;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fs;
+use std::iter::repeat_with;
 use std::path::{Path, PathBuf};
 use tempfile::{tempdir, TempDir};
 
@@ -922,10 +922,8 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
 }
 
 fn random_layer_name() -> LayerName {
-    rand::thread_rng()
-        .sample_iter(rand::distributions::Alphanumeric)
+    repeat_with(fastrand::lowercase)
         .take(15)
-        .map(char::from)
         .collect::<String>()
         .parse()
         .unwrap()

--- a/libcnb/src/layer/test.rs
+++ b/libcnb/src/layer/test.rs
@@ -922,7 +922,7 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
 }
 
 fn random_layer_name() -> LayerName {
-    repeat_with(fastrand::lowercase)
+    repeat_with(fastrand::alphanumeric)
         .take(15)
         .collect::<String>()
         .parse()


### PR DESCRIPTION
Since this usage doesn't need to be cryptographically secure, and `fastrand` is a smaller dependency, and already in the dependency tree (via `tempfile`).

Similar to that discussed in:
https://github.com/Malax/libcnb.rs/pull/277#discussion_r793516863