### PR TITLE
Support connecting to Docker daemon on a remote machine

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Use the `DOCKER_HOST` environment variable to determine the Docker connection strategy, adding support for HTTPS 
 connections in addition to local UNIX sockets. This enables using `libcnb-test` in more complex setups like on CircleCI 
-where the Docker deamon is on a remote machine.
+where the Docker deamon is on a remote machine. ([#305](https://github.com/Malax/libcnb.rs/pull/305))
 
 ## [0.1.0] 2022-02-02
 

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [Unreleased]
 
-## [0.1.1] 2022-02-03
-
-- Connect to Docker demon via HTTP by default, only fall back to local socket/named pipe if no `DOCKER_HOST`
-environment variable is set. ([#305](https://github.com/Malax/libcnb.rs/pull/305))
+- Use the `DOCKER_HOST` environment variable to determine the Docker connection strategy, adding support for HTTPS 
+connections in addition to local UNIX sockets. This enables using `libcnb-test` in more complex setups like on CircleCI 
+where the Docker deamon is on a remote machine.
 
 ## [0.1.0] 2022-02-02
 

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.1.1] 2022-02-03
+
+- Connect to Docker demon via HTTP by default, only fall back to local socket/named pipe if no `DOCKER_HOST`
+environment variable is set. ([#305](https://github.com/Malax/libcnb.rs/pull/305))
+
 ## [0.1.0] 2022-02-02
 
 - Initial release ([#277](https://github.com/Malax/libcnb.rs/pull/277)).

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-test"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.56"
 license = "BSD-3-Clause"

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
-bollard = "0.11.1"
+bollard = { version = "0.11.1", features = ["ssl"] }
 fastrand = "1.7.0"
 fs_extra = "1.2.0"
 libcnb-cargo = { path = "../libcnb-cargo", version = "0.2.1" }

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -108,7 +108,7 @@ impl IntegrationTest {
                 panic!("DOCKER_HOST environment variable is not unicode encoded!")
             }
         }
-        .expect("Could not connect to local Docker deamon");
+        .expect("Could not connect to local Docker daemon");
 
         IntegrationTest {
             app_dir: PathBuf::from(app_dir.as_ref()),

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -89,13 +89,13 @@ impl IntegrationTest {
         let tokio_runtime =
             tokio::runtime::Runtime::new().expect("Could not create internal Tokio runtime");
 
-        let docker = Docker::connect_with_http_defaults()
+        let docker = Docker::connect_with_ssl_defaults()
             .and_then(|docker| {
                 // Bollard will not attempt to connect to Docker before an actual request. Because
                 // we want to ensure a connection can be established (see later comment) we need to
                 // ping Docker here.
                 match tokio_runtime.block_on(docker.ping()) {
-                    // If the connection via HTTP failed and no explicit DOCKER_HOST has been
+                    // If the connection via HTTPS failed and no explicit DOCKER_HOST has been
                     // set, try to connect via a local socket or named pipe. This is a fallback
                     // for local Docker Desktop configurations which currently do not expose
                     // the HTTP API by default.


### PR DESCRIPTION
Previously, `libcnb-test` only used a local socket or named pipe to connect to Docker. This PR changes this to use the connection string from `DOCKER_HOST` to determine where the Docker API is hosted. This PR also adds HTTPS support for Docker connections.

This enables usage of libcnb-test on CircleCI where the Docker deamon is on a remote machine, configured by the `DOCKER_HOST` environment variable.

There is an additional issue on CircleCI where the test is not able to connect to the running container (see: https://circleci.com/docs/2.0/building-docker-images/#accessing-services). This will be addressed in a separate PR.


Closes GUS-W-10533383