### PR TITLE
Fix link to `examples` directory in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,5 +241,5 @@ Hello World!
 
 ### Next Steps
 While the buildpack we've written in this quick start guide is not very useful, it can serve as a starting point for a 
-more useful buildpack. To discover more of the libcnb API, browse the [examples directory](example) and the 
+more useful buildpack. To discover more of the libcnb API, browse the [examples directory](examples) and the 
 [documentation on docs.rs][docs.rs].


### PR DESCRIPTION
Hi 👋🏽 . I'm just getting into CNBs and was delighted to come across `libcnb.rs` (I'm not too fond of writing Bash scripts :). Thanks for all your work on this so far - it seems well designed and documented 👏🏽 .

This little PR just fixes a broken  link that I discovered when clicking on it over at https://crates.io/crates/libcnb.