### PR TITLE
Update cross-compile assistance for Apple silicon

### DIFF
--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Update cross-compile assistance on macOS to use https://github.com/messense/homebrew-macos-cross-toolchains instead of https://github.com/FiloSottile/homebrew-musl-cross. Support for the latter has not been removed, existing setups continue to work as before. ([#312](https://github.com/Malax/libcnb.rs/pull/312))
+
 ## [0.2.1] 2022-01-19
 
 - `cargo libcnb package` now allows multiple targets, as long as there is only one binary target. To support this change, the `BuildError` variants `NoTargetsFound` and `MultipleTargetsFound` have been replaced by `NoBinTargetsFound` and `MultipleBinTargetsFound` respectively. ([#282](https://github.com/Malax/libcnb.rs/pull/282))

--- a/libcnb-cargo/src/cross_compile.rs
+++ b/libcnb-cargo/src/cross_compile.rs
@@ -22,7 +22,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                 r#"For cross-compilation from macOS to x86_64-unknown-linux-musl, a C compiler and
 linker for the target platform must be installed on your computer.
 
-The easiest way to install 'x86_64-unknown-linux-gnu-gcc' is to follow the instructions in the linked
+The easiest way to install 'x86_64-unknown-linux-musl-gcc' is to follow the instructions in the linked
 GitHub repository:
 
 https://github.com/messense/homebrew-macos-cross-toolchains"#,

--- a/libcnb-cargo/src/cross_compile.rs
+++ b/libcnb-cargo/src/cross_compile.rs
@@ -9,16 +9,29 @@ use which::which;
 pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileAssistance {
     // Background: https://omarkhawaja.com/cross-compiling-rust-from-macos-to-linux/
     if target_triple.as_ref() == X86_64_UNKNOWN_LINUX_MUSL && cfg!(target_os = "macos") {
-        let gcc_binary_name = "x86_64-linux-musl-gcc";
+        // There is more than just one binary name here since we also support the binary name for
+        // an older version cross_compile_assistance which suggested installing a different
+        // toolchain.
+        let possible_gcc_binary_names =
+            vec!["x86_64-unknown-linux-musl-gcc", "x86_64-linux-musl-gcc"];
 
-        match which(gcc_binary_name) {
-            Ok(gcc_binary_path) => {
+        possible_gcc_binary_names
+            .iter()
+            .find_map(|binary_name| which(binary_name).ok())
+            .map_or_else(|| CrossCompileAssistance::HelpText(String::from(
+                r#"For cross-compilation from macOS to x86_64-unknown-linux-musl, a C compiler and
+linker for the target platform must be installed on your computer.
+
+The easiest way to install 'x86_64-unknown-linux-gnu-gcc' is to follow the instructions in the linked
+GitHub repository:
+
+https://github.com/messense/homebrew-macos-cross-toolchains"#,
+            )), |gcc_binary_path| {
                 CrossCompileAssistance::Configuration {
                     cargo_env: vec![
                         (
                             // Required until Cargo can auto-detect the musl-cross gcc/linker itself,
-                            // since otherwise it checks for a binary named 'musl-gcc'
-                            // not 'x86_64-linux-musl-gcc':
+                            // since otherwise it checks for a binary named 'musl-gcc':
                             // https://github.com/FiloSottile/homebrew-musl-cross/issues/16
                             // https://github.com/rust-lang/cargo/issues/4133
                             OsString::from("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER"),
@@ -32,17 +45,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                         ),
                     ],
                 }
-            }
-            Err(_) => CrossCompileAssistance::HelpText(String::from(
-                r#"For cross-compilation from macOS to x86_64-unknown-linux-musl, a C compiler and
-linker for the target platform must be installed on your computer.
-
-The easiest way to install 'x86_64-linux-musl-gcc' is to follow the instructions in the linked
-GitHub repository:
-
-https://github.com/FiloSottile/homebrew-musl-cross"#,
-            )),
-        }
+            })
     } else if target_triple.as_ref() == X86_64_UNKNOWN_LINUX_MUSL && cfg!(target_os = "linux") {
         match which("musl-gcc") {
             Ok(_) => CrossCompileAssistance::Configuration { cargo_env: vec![] },

--- a/libcnb-cargo/src/cross_compile.rs
+++ b/libcnb-cargo/src/cross_compile.rs
@@ -22,9 +22,10 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                 r#"For cross-compilation from macOS to x86_64-unknown-linux-musl, a C compiler and
 linker for the target platform must be installed on your computer.
 
-The easiest way to install 'x86_64-unknown-linux-musl-gcc' is to follow the instructions in the linked
-GitHub repository:
+The easiest way to install the required cross-compilation toolchain is to run:
+brew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl
 
+For more information, see:
 https://github.com/messense/homebrew-macos-cross-toolchains"#,
             )), |gcc_binary_path| {
                 CrossCompileAssistance::Configuration {


### PR DESCRIPTION
The current instructions to set-up cross compilation only work on Intel based Macs since [homebrew-musl-cross](https://github.com/FiloSottile/homebrew-musl-cross) is not available for Apple silicon Macs yet: 

- https://github.com/FiloSottile/homebrew-musl-cross/issues/23.

This PR updates the cross-compile assistance to use [homebrew-macos-cross-toolchains](https://github.com/messense/homebrew-macos-cross-toolchains) instead which also supports Apple silicon. However, support for homebrew-musl-cross hasn't been removed, existing installations will continue to work without the need to install new toolchains after this change is released.