### PR TITLE
Make `libcnb_runtime_build` and `libcnb_runtime_detect` public

### DIFF
--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -35,7 +35,9 @@ pub use platform::*;
 pub use toml_file::*;
 
 pub use buildpack::Buildpack;
-pub use runtime::libcnb_runtime;
+pub use runtime::{
+    libcnb_runtime, libcnb_runtime_build, libcnb_runtime_detect, BuildArgs, DetectArgs,
+};
 
 const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =
     data::buildpack::BuildpackApi { major: 0, minor: 6 };

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -60,7 +60,6 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
         .and_then(Path::file_name)
         .and_then(OsStr::to_str);
 
-    #[cfg(any(target_family = "unix"))]
     let result = match current_exe_file_name {
         Some("detect") => libcnb_runtime_detect(buildpack, parse_detect_args_or_exit()),
         Some("build") => libcnb_runtime_build(buildpack, parse_build_args_or_exit()),


### PR DESCRIPTION
This exposes `libcnb_runtime_build` and `libcnb_runtime_detect` (and associated types) so that they can be used by other crates.

For my use case, instead of building separate executable for each buildpack, I would like to combine several buildpacks into an existing CLI executable and delegate to their `detect` and `build` methods. This change allows me to do that without rewriting alot of the code contained in these two functions e.g.

```rust
/// A local trait for buildpacks that extends `libcnb::Buildpack`
///
/// Why? To provide some additional introspection and the ability
/// to compile several buildpacks into a single binary and call
/// their `detect` and `build` methods.
pub trait BuildpackTrait: libcnb::Buildpack {
    ...

    /// Run the buildpack's `detect` method
    fn detect_with(&self, platform_dir: &Path, build_plan: &Path) -> Result<i32>
    where
        Self: Sized,
    {
        env::set_var("CNB_STACK_ID", CNB_STACK_ID);

        let buildpack_dir = self.ensure_dir()?;
        env::set_var("CNB_BUILDPACK_DIR", buildpack_dir);

        match libcnb_runtime_detect(
            self,
            DetectArgs {
                platform_dir_path: PathBuf::from(platform_dir),
                build_plan_path: PathBuf::from(build_plan),
            },
        ) {
            Ok(code) => Ok(code),
            Err(error) => bail!(
                "While running `detect` for buildpack `{}`: {}",
                Self::id(),
                error
            ),
        }
    }
```