### PR TITLE
Enable `clippy::pedantic` in examples and integration tests

### DIFF
--- a/examples/example-01-basics/src/main.rs
+++ b/examples/example-01-basics/src/main.rs
@@ -1,3 +1,7 @@
+// Enable Clippy lints that are disabled by default.
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};

--- a/examples/example-02-ruby-sample/Cargo.toml
+++ b/examples/example-02-ruby-sample/Cargo.toml
@@ -11,7 +11,6 @@ serde = "1.0.133"
 sha2 = "0.10.1"
 tar = "0.4.38"
 tempfile = "3.3.0"
-toml = "0.5.8"
 ureq = "2.4.0"
 
 [dev-dependencies]

--- a/examples/example-02-ruby-sample/src/layers/bundler.rs
+++ b/examples/example-02-ruby-sample/src/layers/bundler.rs
@@ -78,10 +78,10 @@ impl Layer for BundlerLayer {
         util::sha256_checksum(context.app_dir.join("Gemfile.lock"))
             .map_err(RubyBuildpackError::CouldNotGenerateChecksum)
             .map(|checksum| {
-                if checksum != layer.content_metadata.metadata.gemfile_lock_checksum {
-                    ExistingLayerStrategy::Update
-                } else {
+                if checksum == layer.content_metadata.metadata.gemfile_lock_checksum {
                     ExistingLayerStrategy::Keep
+                } else {
+                    ExistingLayerStrategy::Update
                 }
             })
     }

--- a/examples/example-02-ruby-sample/src/main.rs
+++ b/examples/example-02-ruby-sample/src/main.rs
@@ -1,3 +1,9 @@
+// Enable Clippy lints that are disabled by default.
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+// This lint is too noisy and enforces a style that reduces readability in many cases.
+#![allow(clippy::module_name_repetitions)]
+
 use crate::layers::{BundlerLayer, RubyLayer};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::launch::{Launch, ProcessBuilder};

--- a/examples/example-02-ruby-sample/tests/integration_test.rs
+++ b/examples/example-02-ruby-sample/tests/integration_test.rs
@@ -3,6 +3,10 @@
 //! All integration tests are skipped by default (using the `ignore` attribute),
 //! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
 
+// Enable Clippy lints that are disabled by default.
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+
 use libcnb_test::IntegrationTest;
 use std::io;
 use std::io::{Read, Write};

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -3,6 +3,10 @@
 //! All integration tests are skipped by default (using the `ignore` attribute),
 //! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
 
+// Enable Clippy lints that are disabled by default.
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+
 use libcnb_test::{BuildpackReference, IntegrationTest};
 use tempfile::tempdir;
 


### PR DESCRIPTION
The Rust attributes used to enable additional lints only apply to the current binary/library/..., so must be added to every `main.rs`, `lib.rs` and integration test until such time as Cargo supports a global config:
https://github.com/rust-lang/cargo/issues/5034

As an example of the benefit of having `clippy::pedantic` enabled, it would have caught this issue with the integration tests found during code review:
https://github.com/Malax/libcnb.rs/pull/277#discussion_r796818127

I've skipped adding `unused_crate_dependencies` to the examples and integration tests, since it gives false-positives for integration-test-only dependencies such as `libcnb-test`. Whilst these can be suppressed via:

```
#[cfg(test)]
use libcnb_test as _;
```

...adding these to our examples risks cluttering them.

There likely is still value in using that lint for our main crates (which will see more frequent dependency churn, so risk of unused deps), but for our examples it doesn't seem worth the trade-offs.

Temporarily enabling `unused_crate_dependencies` locally did find an used `toml` dependency in `example-02-ruby-sample` however :-)

Fixes #302.