### PR TITLE
Skip integration tests when using `cargo test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,22 +38,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0
-      - name: Install musl-tools
-        run: sudo apt-get install musl-tools --no-install-recommends
       - name: Update Rust toolchain
         run: rustup update
-      - name: Install Rust linux-musl target
-        run: rustup target add x86_64-unknown-linux-musl
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
-      - name: Install Pack CLI
-        uses: buildpacks/github-actions/setup-pack@v4.5.1
-      - name: Configure Pack CLI
-        # Default to a small non-libc image for faster CI + to validate the static musl cross-compilation.
-        # Adjust pull-policy to prevent redundant image-pulling, which slows CI and risks hitting registry rate limits.
-        run: |
-          pack config default-builder cnbs/sample-builder:alpine
-          pack config pull-policy if-not-present
       - name: Run tests
         run: cargo test --all-features
 
@@ -78,6 +66,9 @@ jobs:
         run: |
           pack config default-builder cnbs/sample-builder:alpine
           pack config pull-policy if-not-present
+      - name: Run integration tests
+        # Runs any tests annotated with the `#[ignore]` attribute (which in this repo, are all of the integration tests).
+        run: cargo test -- --ignored
       - name: Compile and package example-01-basics
         run: cargo run --package libcnb-cargo -- libcnb package
         working-directory: ./examples/example-01-basics

--- a/examples/example-02-ruby-sample/tests/integration_test.rs
+++ b/examples/example-02-ruby-sample/tests/integration_test.rs
@@ -1,3 +1,8 @@
+//! Integration tests using libcnb-test.
+//!
+//! All integration tests are skipped by default (using the `ignore` attribute),
+//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+
 use libcnb_test::IntegrationTest;
 use std::io;
 use std::io::{Read, Write};
@@ -6,6 +11,7 @@ use std::net::ToSocketAddrs;
 use std::time::Duration;
 
 #[test]
+#[ignore]
 fn basic() {
     IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app").run_test(
         |context| {

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -1,7 +1,13 @@
+//! Integration tests using libcnb-test.
+//!
+//! All integration tests are skipped by default (using the `ignore` attribute),
+//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+
 use libcnb_test::{BuildpackReference, IntegrationTest};
 use tempfile::tempdir;
 
 #[test]
+#[ignore]
 #[should_panic(expected = "pack command failed with exit-code 1!
 
 pack stdout:


### PR DESCRIPTION
The integration tests in the examples and `libcnb-test` are now annotated with the [`#[ignore]` attribute](https://doc.rust-lang.org/book/ch11-02-running-tests.html#ignoring-some-tests-unless-specifically-requested), which causes them to be skipped by default when using `cargo test`. 

The skipped tests will be listed in the test log output as "ignored", eg:

<img width="861" alt="screenshot of cargo test output" src="https://user-images.githubusercontent.com/501702/153724105-0a4689b8-583f-4894-9974-3afd0234c5bb.png">

To run the integration tests, `cargo test -- --ignored` must be used.

This has several benefits:
- Allows easily running just the quicker subset of the tests (unit tests and doctests) when developing locally, via `cargo test`, without the need to pass a bunch of additional arguments to `cargo test` to limit the tests being run.
- Means the integration tests can be moved from the CI `test` job to the `integration` job (alongside the existing `cargo libcnb package` test), which evens out the CI end to end time, and means faster feedback in case of failures of the unit tests (particularly since the `test` job no longer needs to duplicate all of the musl-related setup steps).
- Means a new contributor making a simple change to a Rust buildpack (or to libcnb itself) doesn't need to install all of the cross-compilation tooling locally in order for `cargo test` to work out of the box.

Fixes #301.