### PR TITLE
Make use of implicitly named `format!` args

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# libcnb.rs [![Build Status]][ci] [![Docs]][docs.rs] [![Latest Version]][crates.io] [![Rustc Version 1.56+]][rustc]
+# libcnb.rs [![Build Status]][ci] [![Docs]][docs.rs] [![Latest Version]][crates.io] [![Rustc Version 1.58+]][rustc]
 
 [Build Status]: https://img.shields.io/github/workflow/status/Malax/libcnb/CI/main
 [ci]: https://github.com/Malax/libcnb.rs/actions/workflows/ci.yml?query=branch%3Amain
@@ -6,8 +6,8 @@
 [docs.rs]: https://docs.rs/libcnb/*/libcnb/
 [Latest Version]: https://img.shields.io/crates/v/libcnb.svg
 [crates.io]: https://crates.io/crates/libcnb
-[Rustc Version 1.56+]: https://img.shields.io/badge/rustc-1.56+-lightgray.svg
-[rustc]: https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html
+[Rustc Version 1.58+]: https://img.shields.io/badge/rustc-1.58+-lightgray.svg
+[rustc]: https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html
 
 `libcnb.rs` is a framework for writing [Cloud Native Buildpacks](https://buildpacks.io) in Rust. It is an opinionated implementation adding language constructs and convenience methods for working with the spec. It values strong adherence to the spec and data formats.
 

--- a/examples/basics/Cargo.toml
+++ b/examples/basics/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examples-basics"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 
 [dependencies]
 libcnb = { path = "../../libcnb" }

--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examples-ruby-sample"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 
 [dependencies]
 flate2 = "1.0.22"

--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update cross-compile assistance on macOS to use https://github.com/messense/homebrew-macos-cross-toolchains instead of https://github.com/FiloSottile/homebrew-musl-cross. Support for the latter has not been removed, existing setups continue to work as before. ([#312](https://github.com/Malax/libcnb.rs/pull/312))
 - `libcnb-cargo` now cross-compiles and packages all binary targets of the buildpack. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/Malax/libcnb.rs/pull/314))
+- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 
 ## [0.2.1] 2022-01-19
 

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb-cargo"
 version = "0.2.1"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 license = "BSD-3-Clause"
 description = "Cargo command for managing buildpacks written with libcnb.rs"
 keywords = ["buildpacks", "CNB"]

--- a/libcnb-cargo/src/main.rs
+++ b/libcnb-cargo/src/main.rs
@@ -50,7 +50,7 @@ fn handle_libcnb_package(matches: &ArgMatches) {
     let current_dir = match std::env::current_dir() {
         Ok(current_dir) => current_dir,
         Err(io_error) => {
-            error!("Could not determine current directory: {}", io_error);
+            error!("Could not determine current directory: {io_error}");
             std::process::exit(1);
         }
     };
@@ -61,14 +61,11 @@ fn handle_libcnb_package(matches: &ArgMatches) {
         Err(error) => {
             match error {
                 BuildpackDataError::IoError(io_error) => {
-                    error!("Unable to read buildpack metadata: {}", io_error);
+                    error!("Unable to read buildpack metadata: {io_error}");
                     error!("Hint: Verify that a readable file named \"buildpack.toml\" exists at the root of your project.");
                 }
                 BuildpackDataError::DeserializationError(deserialization_error) => {
-                    error!(
-                        "Unable to deserialize buildpack metadata: {}",
-                        deserialization_error
-                    );
+                    error!("Unable to deserialize buildpack metadata: {deserialization_error}");
                     error!("Hint: Verify that your \"buildpack.toml\" is valid.");
                 }
             }
@@ -89,7 +86,7 @@ fn handle_libcnb_package(matches: &ArgMatches) {
     {
         Ok(cargo_metadata) => cargo_metadata,
         Err(error) => {
-            error!("Could not obtain metadata from Cargo: {}", error);
+            error!("Could not obtain metadata from Cargo: {error}");
             std::process::exit(1);
         }
     };
@@ -115,15 +112,12 @@ fn handle_libcnb_package(matches: &ArgMatches) {
         info!("Determining automatic cross-compile settings...");
         match cross_compile_assistance(target_triple) {
             CrossCompileAssistance::HelpText(help_text) => {
-                error!("{}", help_text);
+                error!("{help_text}");
                 info!("To disable cross-compile assistance, pass --no-cross-compile-assistance.");
                 std::process::exit(1);
             }
             CrossCompileAssistance::NoAssistance => {
-                warn!(
-                    "Could not determine automatic cross-compile settings for target triple {}.",
-                    &target_triple
-                );
+                warn!("Could not determine automatic cross-compile settings for target triple {target_triple}.");
                 warn!("This is not an error, but without proper cross-compile settings in your Cargo manifest and locally installed toolchains, compilation might fail.");
                 warn!("To disable this warning, pass --no-cross-compile-assistance.");
                 vec![]
@@ -132,7 +126,7 @@ fn handle_libcnb_package(matches: &ArgMatches) {
         }
     };
 
-    info!("Building binaries ({})...", &target_triple);
+    info!("Building binaries ({target_triple})...");
 
     let buildpack_binaries = match build_buildpack_binaries(
         &current_dir,
@@ -148,18 +142,14 @@ fn handle_libcnb_package(matches: &ArgMatches) {
             match build_error {
                 BuildBinariesError::ConfigError(_) => {}
                 BuildBinariesError::BuildError(target_name, BuildError::IoError(io_error)) => {
-                    error!(
-                        "IO error while executing Cargo for target {}: {}",
-                        target_name, io_error
-                    );
+                    error!("IO error while executing Cargo for target {target_name}: {io_error}");
                 }
                 BuildBinariesError::BuildError(
                     target_name,
                     BuildError::UnexpectedCargoExitStatus(exit_status),
                 ) => {
                     error!(
-                        "Unexpected Cargo exit status for target {}: {}",
-                        target_name,
+                        "Unexpected Cargo exit status for target {target_name}: {}",
                         exit_status
                             .code()
                             .map_or_else(|| String::from("<unknown>"), |code| code.to_string())
@@ -167,10 +157,7 @@ fn handle_libcnb_package(matches: &ArgMatches) {
                     error!("Examine Cargo output for details and potential compilation errors.");
                 }
                 BuildBinariesError::MissingBuildpackTarget(target_name) => {
-                    error!(
-                        "Configured buildpack target name {} could not be found!",
-                        target_name
-                    );
+                    error!("Configured buildpack target name {target_name} could not be found!");
                 }
             }
 
@@ -181,7 +168,7 @@ fn handle_libcnb_package(matches: &ArgMatches) {
     info!("Writing buildpack directory...");
     if output_path.exists() {
         if let Err(error) = fs::remove_dir_all(&output_path) {
-            error!("Could not remove buildpack directory: {}", &error);
+            error!("Could not remove buildpack directory: {error}");
             std::process::exit(1);
         };
     }
@@ -191,7 +178,7 @@ fn handle_libcnb_package(matches: &ArgMatches) {
         &buildpack_data.buildpack_descriptor_path,
         &buildpack_binaries,
     ) {
-        error!("IO error while writing buildpack directory: {}", io_error);
+        error!("IO error while writing buildpack directory: {io_error}");
         std::process::exit(1);
     };
 
@@ -213,7 +200,7 @@ fn setup_logging() {
         .verbosity(2) // LevelFilter::Info
         .init()
     {
-        eprintln!("Unable to initialize logger: {}", error);
+        eprintln!("Unable to initialize logger: {error}");
         std::process::exit(1);
     }
 }

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `#[must_use]` to `BuildPlan` and `BuildPlanBuilder` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
 - Add `exec_d` module with types representing the output of an `exec.d` program ([#324](https://github.com/Malax/libcnb.rs/pull/324)).
+- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 
 ## [0.4.0] 2022-01-14
 

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb-data"
 version = "0.4.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 license = "BSD-3-Clause"
 description = "Types for data formats specified in the Cloud Native Buildpack specification, used by libcnb.rs"
 keywords = ["buildpacks", "CNB"]

--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [0.1.1] 2022-01-14
 
 - Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233) and [#275](https://github.com/Malax/libcnb.rs/pull/275)).
+- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 
 ## [0.1.0] 2021-12-08
 

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb-proc-macros"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 license = "BSD-3-Clause"
 description = "Procedural macros used within libcnb.rs"
 repository = "https://github.com/Malax/libcnb.rs/tree/main/libcnb-proc-macros"

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -3,12 +3,13 @@
 ## [Unreleased]
 
 - `libcnb-test` now cross-compiles and packages all binary targets of the buildpack for an integration test. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/Malax/libcnb.rs/pull/314))
+- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 
 ## [0.1.1] 2022-02-04
 
 - Use the `DOCKER_HOST` environment variable to determine the Docker connection strategy, adding support for HTTPS 
 connections in addition to local UNIX sockets. This enables using `libcnb-test` in more complex setups like on CircleCI 
-where the Docker deamon is on a remote machine. ([#305](https://github.com/Malax/libcnb.rs/pull/305))
+where the Docker daemon is on a remote machine. ([#305](https://github.com/Malax/libcnb.rs/pull/305))
 
 ## [0.1.0] 2022-02-02
 

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb-test"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 license = "BSD-3-Clause"
 description = "An integration testing framework for buildpacks written with libcnb.rs"
 keywords = ["buildpacks", "CNB"]

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -103,7 +103,7 @@ async fn container_exec_result_from_bollard(
                         .stdout_raw
                         .append(&mut message.to_vec()),
 
-                    x => unimplemented!("message unimplemented: {}", x),
+                    x => unimplemented!("message unimplemented: {x}"),
                 }
             }
         }

--- a/libcnb-test/src/container_port_mapping.rs
+++ b/libcnb-test/src/container_port_mapping.rs
@@ -75,7 +75,7 @@ pub(crate) fn port_mapped_container_config(ports: &[u16]) -> bollard::container:
                     .iter()
                     .map(|port| {
                         (
-                            format!("{}/tcp", port),
+                            format!("{port}/tcp"),
                             Some(vec![PortBinding {
                                 host_ip: None,
                                 host_port: None,
@@ -91,7 +91,7 @@ pub(crate) fn port_mapped_container_config(ports: &[u16]) -> bollard::container:
                 .iter()
                 .map(|port| {
                     (
-                        format!("{}/tcp", port),
+                        format!("{port}/tcp"),
                         #[allow(clippy::zero_sized_map_values)]
                         HashMap::new(), // Bollard requires this zero sized value map,
                     )

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -99,10 +99,7 @@ impl IntegrationTest {
             {
                 Docker::connect_with_ssl_defaults()
             }
-            Ok(docker_host) => panic!(
-                "Cannot connect to unsupported DOCKER_HOST '{}'",
-                docker_host
-            ),
+            Ok(docker_host) => panic!("Cannot connect to unsupported DOCKER_HOST '{docker_host}'"),
             Err(VarError::NotPresent) => Docker::connect_with_local_defaults(),
             Err(VarError::NotUnicode(_)) => {
                 panic!("DOCKER_HOST environment variable is not unicode encoded!")

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `#[must_use]` to `DetectResult`, `DetectResultBuilder`, `PassDetectResultBuilder`, `FailDetectResultBuilder`, `BuildResult` and `BuildResultBuilder` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
 - Add `additional_buildpack_binary_path!` macro to resolve paths to additional buildpack binaries. Only works when the buildpack is packaged with `libcnb-cargo`/`libcnb-test`. ([#320](https://github.com/Malax/libcnb.rs/pull/320))
+- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 
 ## [0.5.0] 2022-01-14
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb"
 version = "0.5.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 license = "BSD-3-Clause"
 description = "A framework for writing Cloud Native Buildpacks in Rust"
 keywords = ["buildpacks", "CNB"]

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -217,9 +217,7 @@ fn delete_layer<P: AsRef<Path>>(
     layer_name: &LayerName,
 ) -> Result<(), std::io::Error> {
     let layer_dir = layers_dir.as_ref().join(layer_name.as_str());
-    let layer_toml = layers_dir
-        .as_ref()
-        .join(format!("{}.toml", layer_name.as_ref()));
+    let layer_toml = layers_dir.as_ref().join(format!("{layer_name}.toml"));
 
     default_on_not_found(fs::remove_dir_all(&layer_dir))?;
     default_on_not_found(fs::remove_file(&layer_toml))?;
@@ -235,9 +233,7 @@ fn write_layer<M: Serialize, P: AsRef<Path>>(
     layer_content_metadata: &LayerContentMetadata<M>,
 ) -> Result<(), WriteLayerError> {
     let layer_dir = layers_dir.as_ref().join(layer_name.as_str());
-    let layer_content_metadata_path = layers_dir
-        .as_ref()
-        .join(format!("{}.toml", layer_name.as_ref()));
+    let layer_content_metadata_path = layers_dir.as_ref().join(format!("{layer_name}.toml"));
 
     fs::create_dir_all(&layer_dir)?;
     layer_env.write_to_layer_dir(&layer_dir)?;
@@ -251,7 +247,7 @@ fn read_layer<M: DeserializeOwned, P: AsRef<Path>>(
     layer_name: &LayerName,
 ) -> Result<Option<LayerData<M>>, ReadLayerError> {
     let layer_dir_path = layers_dir.as_ref().join(layer_name.as_str());
-    let layer_toml_path = layers_dir.as_ref().join(format!("{}.toml", layer_name));
+    let layer_toml_path = layers_dir.as_ref().join(format!("{layer_name}.toml"));
 
     if !layer_dir_path.exists() && !layer_toml_path.exists() {
         return Ok(None);
@@ -315,7 +311,7 @@ mod tests {
 
         fs::create_dir_all(&layer_dir).unwrap();
         fs::write(
-            layers_dir.join(format!("{}.toml", &layer_name)),
+            layers_dir.join(format!("{layer_name}.toml")),
             r#"
             [types]
             launch = true
@@ -328,7 +324,7 @@ mod tests {
         super::delete_layer(&layers_dir, &layer_name).unwrap();
 
         assert!(!layer_dir.exists());
-        assert!(!layers_dir.join(format!("{}.toml", &layer_name)).exists());
+        assert!(!layers_dir.join(format!("{layer_name}.toml")).exists());
     }
 
     #[test]
@@ -339,7 +335,7 @@ mod tests {
         let layer_dir = layers_dir.join(layer_name.as_str());
 
         fs::write(
-            layers_dir.join(format!("{}.toml", &layer_name)),
+            layers_dir.join(format!("{layer_name}.toml")),
             r#"
             [types]
             launch = true
@@ -352,7 +348,7 @@ mod tests {
         super::delete_layer(&layers_dir, &layer_name).unwrap();
 
         assert!(!layer_dir.exists());
-        assert!(!layers_dir.join(format!("{}.toml", &layer_name)).exists());
+        assert!(!layers_dir.join(format!("{layer_name}.toml")).exists());
     }
 
     #[test]
@@ -399,7 +395,7 @@ mod tests {
         );
 
         let layer_content_metadata: LayerContentMetadata<GenericMetadata> =
-            read_toml_file(layers_dir.join(format!("{}.toml", layer_name))).unwrap();
+            read_toml_file(layers_dir.join(format!("{layer_name}.toml"))).unwrap();
 
         assert_eq!(
             layer_content_metadata.types,
@@ -482,7 +478,7 @@ mod tests {
         assert!(!layer_dir.join("env/SOME_OTHER_ENV_VAR.default").exists());
 
         let layer_content_metadata: LayerContentMetadata<GenericMetadata> =
-            read_toml_file(layers_dir.join(format!("{}.toml", layer_name))).unwrap();
+            read_toml_file(layers_dir.join(format!("{layer_name}.toml"))).unwrap();
 
         assert_eq!(
             layer_content_metadata.types,
@@ -509,7 +505,7 @@ mod tests {
 
         fs::create_dir_all(&layer_dir).unwrap();
         fs::write(
-            layers_dir.join(format!("{}.toml", &layer_name)),
+            layers_dir.join(format!("{layer_name}.toml")),
             r#"
             [types]
             launch = true
@@ -578,7 +574,7 @@ mod tests {
 
         fs::create_dir_all(&layer_dir).unwrap();
         fs::write(
-            layers_dir.join(format!("{}.toml", &layer_name)),
+            layers_dir.join(format!("{layer_name}.toml")),
             r#"
             [types
             build = true
@@ -611,7 +607,7 @@ mod tests {
 
         fs::create_dir_all(&layer_dir).unwrap();
         fs::write(
-            layers_dir.join(format!("{}.toml", &layer_name)),
+            layers_dir.join(format!("{layer_name}.toml")),
             r#"
             [types]
             build = true
@@ -661,7 +657,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let layers_dir = temp_dir.path();
 
-        fs::write(layers_dir.join(format!("{}.toml", &layer_name)), "").unwrap();
+        fs::write(layers_dir.join(format!("{layer_name}.toml")), "").unwrap();
 
         match super::read_layer::<GenericMetadata, _>(&layers_dir, &layer_name) {
             Ok(None) => {}

--- a/libcnb/src/layer/test.rs
+++ b/libcnb/src/layer/test.rs
@@ -165,7 +165,7 @@ fn create() {
         temp_dir
             .path()
             .join("layers")
-            .join(format!("{}.toml", &layer_name)),
+            .join(format!("{layer_name}.toml")),
     )
     .unwrap();
 
@@ -234,7 +234,7 @@ fn create_then_update() {
         temp_dir
             .path()
             .join("layers")
-            .join(format!("{}.toml", &layer_name)),
+            .join(format!("{layer_name}.toml")),
     )
     .unwrap();
 
@@ -326,7 +326,7 @@ fn create_then_recreate() {
         temp_dir
             .path()
             .join("layers")
-            .join(format!("{}.toml", &layer_name)),
+            .join(format!("{layer_name}.toml")),
     )
     .unwrap();
 
@@ -420,7 +420,7 @@ fn create_then_keep() {
         temp_dir
             .path()
             .join("layers")
-            .join(format!("{}.toml", &layer_name)),
+            .join(format!("{layer_name}.toml")),
     )
     .unwrap();
 
@@ -476,7 +476,7 @@ fn update_with_incompatible_metadata_replace() {
     let test_layer_toml = temp_dir
         .path()
         .join("layers")
-        .join(format!("{}.toml", layer_name.as_str()));
+        .join(format!("{layer_name}.toml"));
 
     fs::write(
         &test_layer_toml,
@@ -512,7 +512,7 @@ v = "3.2.1"
         temp_dir
             .path()
             .join("layers")
-            .join(format!("{}.toml", &layer_name)),
+            .join(format!("{layer_name}.toml")),
     )
     .unwrap();
 
@@ -566,7 +566,7 @@ fn update_with_incompatible_metadata_recreate() {
     let test_layer_toml = temp_dir
         .path()
         .join("layers")
-        .join(format!("{}.toml", layer_name.as_str()));
+        .join(format!("{layer_name}.toml"));
 
     fs::write(
         &test_layer_toml,
@@ -600,7 +600,7 @@ versi_on = "3.2.1"
         temp_dir
             .path()
             .join("layers")
-            .join(format!("{}.toml", &layer_name)),
+            .join(format!("{layer_name}.toml")),
     )
     .unwrap();
 
@@ -667,7 +667,7 @@ fn error_handling_no_directory() {
     let layer_toml_path = temp_dir
         .path()
         .join("layers")
-        .join(format!("{}.toml", layer_name.as_str()));
+        .join(format!("{layer_name}.toml"));
 
     fs::write(
         &layer_toml_path,

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -37,11 +37,7 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
                     "This buildpack ({}) uses Cloud Native Buildpacks API version {}.",
                     &buildpack_descriptor.buildpack.id, &buildpack_descriptor.api,
                 );
-
-                eprintln!(
-                    "But the underlying libcnb.rs library requires CNB API {}.",
-                    LIBCNB_SUPPORTED_BUILDPACK_API
-                );
+                eprintln!("But the underlying libcnb.rs library requires CNB API {LIBCNB_SUPPORTED_BUILDPACK_API}.");
 
                 exit(254)
             }


### PR DESCRIPTION
In Rust 1.58, support for implicitly named arguments to `format!` (and related) was stabilised:
https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html
https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1580-2022-01-13

This switches applicable usages to the new, more readable syntax, and bumps the MSRV to Rust 1.58. (We'll likely need to bump the MSRV again for the stabilised `strip` feature in Rust 1.59, which means it's not worth forgoing the bump here and saying we won't use the new format feature for now.)

I've bumped the MSRV for all crates (even those not using the new syntax) for consistency and to prevent us forgetting to adjust the remaining crates if they ever start using the new syntax in the future.

GUS-W-10727905.