### PR TITLE
Add `additional_buildpack_binary_path` macro

### DIFF
--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add a `verify_bin_target_exists!` macro for verifying existence of binary targets in the current crate. ([#320](https://github.com/Malax/libcnb.rs/pull/320))
+
 ## [0.1.1] 2022-01-14
 
 - Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233) and [#275](https://github.com/Malax/libcnb.rs/pull/275)).

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -13,6 +13,7 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 proc-macro = true
 
 [dependencies]
+cargo_metadata = "0.14.1"
 fancy-regex = "0.7.1"
 quote = "1.0.14"
 syn = { version = "1.0.85", features = ["full"] }

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add `#[must_use]` to `DetectResult`, `DetectResultBuilder`, `PassDetectResultBuilder`, `FailDetectResultBuilder`, `BuildResult` and `BuildResultBuilder` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
+- Add `additional_buildpack_binary_path!` macro to resolve paths to additional buildpack binaries. Only works when the buildpack is packaged with `libcnb-cargo`/`libcnb-test`. ([#320](https://github.com/Malax/libcnb.rs/pull/320))
 
 ## [0.5.0] 2022-01-14
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -13,6 +13,7 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 [dependencies]
 anyhow = { version = "1.0.52", optional = true }
 libcnb-data = { path = "../libcnb-data", version = "0.4.0" }
+libcnb-proc-macros = { version = "0.1.1", path = "../libcnb-proc-macros" }
 serde = { version = "1.0.133", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"

--- a/libcnb/src/internals.rs
+++ b/libcnb/src/internals.rs
@@ -1,0 +1,6 @@
+// Used by the libcnb::additional_buildpack_binary_path macro.
+//
+// We cannot use `::libcnb_proc_macros::verify_bin_target_exists` in our macros directly as this
+// would require every crate to explicitly import the `libcnb_proc_macros` crate as crates can't
+// use code from transitive dependencies.
+pub use libcnb_proc_macros::verify_bin_target_exists;

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -92,6 +92,18 @@ macro_rules! buildpack_main {
 /// with the name of file.
 ///
 /// Note: This only works properly if the buildpack is packaged with `libcnb-cargo`/`libcnb-test`.
+///
+/// ```no_run,compile_fail
+/// use libcnb::additional_buildpack_binary_path;
+/// # let layer_dir = std::path::PathBuf::from(".");
+///
+/// std::fs::copy(
+///     // This would not compile in this doctest since there is no `runtime_tool` binary target.
+///     additional_buildpack_binary_path!("runtime_tool"),
+///     layer_dir.join("runtime_tool"),
+/// )
+/// .unwrap();
+/// ```
 #[macro_export]
 macro_rules! additional_buildpack_binary_path {
     ($target_name:expr) => {


### PR DESCRIPTION
Follow-up to: #314 

Resolves the path to an additional buildpack binary by Cargo target name when the buildpack is packaged with `libcnb-cargo` or `libcnb-test`.

This can be used to copy additional binaries to layers or use them for exec.d. To add an additional binary to a buildpack, add a new file with a main function to `bin/`. Cargo will [automatically configure it as a binary target](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#target-auto-discovery) with the name of file.

 Note: This only works properly if the buildpack is packaged with `libcnb-cargo`/`libcnb-test`.

## Implementation notes:

This follows the pattern for the existing proc macro where the proc macro itself only concerns itself with the logic that strictly requires a proc macro. In this case, verifying that the given binary target name is valid. Additional logic is implemented in a regular macro (here: [additional_buildpack_binary_path](https://github.com/Malax/libcnb.rs/pull/320/files#diff-7bd0cf110112f04611a6f19e1f6dc0248913c7493e0a45948258ad9333e23565R85-R117)).

Strictly speaking, the macro should live in `libcnb-cargo` as it only works when a buildpack is packaged with `libcnb-cargo`. However, since `libcnb-cargo` already is a library for implementing packaging, adding a dependency to it from an actual buildpack seemed weird. It also would would hinder discoverability. Therefore, I decided to add it to `libcnb` proper.

I'm slightly unhappy with the hardcoding of the path to the `additional-bin` directory in `libcnb`. I considered adding shared code between `libcnb-cargo` and `libcnb` that concerns itself with the construction of that path. To make that work, we would've needed to create a new shared crate to avoid circular dependencies (i.e. `libcnb-common`). For now, this seems to be overkill but should be reconsidered when we have more use-cases for a shared crate.

Closes GUS-W-10695287