### PR TITLE
Add exec.d related types

### DIFF
--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add `#[must_use]` to `BuildPlan` and `BuildPlanBuilder` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
+- Add `exec_d` module with types representing the output of an `exec.d` program ([#324](https://github.com/Malax/libcnb.rs/pull/324)).
 
 ## [0.4.0] 2022-01-14
 

--- a/libcnb-data/src/exec_d.rs
+++ b/libcnb-data/src/exec_d.rs
@@ -39,7 +39,7 @@ libcnb_newtype!(
     /// let key: ExecDProgramOutputKey = exec_d_program_output_key!("PATH");
     /// ```
     exec_d_program_output_key,
-    /// A key of from exec.d program output
+    /// A key of exec.d program output
     ///
     /// It MUST only contain numbers, letters, and the characters `_` and `-`.
     ///

--- a/libcnb-data/src/exec_d.rs
+++ b/libcnb-data/src/exec_d.rs
@@ -2,6 +2,9 @@ use crate::newtypes::libcnb_newtype;
 use serde::Serialize;
 use std::collections::HashMap;
 
+/// Output of a CNB exec.d program.
+///
+/// See [Cloud Native Buildpack specification](https://github.com/buildpacks/spec/blob/main/buildpack.md#execd)
 #[derive(Serialize, Clone)]
 pub struct ExecDProgramOutput(HashMap<ExecDProgramOutputKey, String>);
 

--- a/libcnb-data/src/exec_d.rs
+++ b/libcnb-data/src/exec_d.rs
@@ -1,5 +1,111 @@
+use crate::newtypes::libcnb_newtype;
 use serde::Serialize;
 use std::collections::HashMap;
 
-#[derive(Serialize)]
-pub type ExecD = HashMap<String, String>;
+#[derive(Serialize, Clone)]
+pub struct ExecDProgramOutput(HashMap<ExecDProgramOutputKey, String>);
+
+impl ExecDProgramOutput {
+    #[must_use]
+    pub fn new(map: HashMap<ExecDProgramOutputKey, String>) -> Self {
+        Self(map)
+    }
+}
+
+impl<K: Into<ExecDProgramOutputKey>, V: Into<String>, A: IntoIterator<Item = (K, V)>> From<A>
+    for ExecDProgramOutput
+{
+    fn from(a: A) -> Self {
+        Self(
+            a.into_iter()
+                .map(|(key, value)| (key.into(), value.into()))
+                .collect(),
+        )
+    }
+}
+
+libcnb_newtype!(
+    exec_d,
+    /// Construct a [`ExecDProgramOutputKey`] value at compile time.
+    ///
+    /// Passing a string that is not a valid `ExecDProgramOutputKey` value will yield a compilation
+    /// error.
+    ///
+    /// # Examples:
+    /// ```
+    /// use libcnb_data::exec_d::ExecDProgramOutputKey;
+    /// use libcnb_data::exec_d_program_output_key;
+    ///
+    /// let key: ExecDProgramOutputKey = exec_d_program_output_key!("PATH");
+    /// ```
+    exec_d_program_output_key,
+    /// A key of from exec.d program output
+    ///
+    /// It MUST only contain numbers, letters, and the characters `_` and `-`.
+    ///
+    /// Use the [`exec_d_program_output_key`](crate::exec_d_program_output_key) macro to construct
+    /// a `ExecDProgramOutputKey` from a literal string. To parse a dynamic string into a
+    /// `ExecDProgramOutputKey`, use [`str::parse`](str::parse).
+    ///
+    /// # Examples
+    /// ```
+    /// use libcnb_data::exec_d::ExecDProgramOutputKey;
+    /// use libcnb_data::exec_d_program_output_key;
+    ///
+    /// let from_literal = exec_d_program_output_key!("ENV_VAR");
+    ///
+    /// let input = "ENV_VAR";
+    /// let from_dynamic: ExecDProgramOutputKey = input.parse().unwrap();
+    /// assert_eq!(from_dynamic, from_literal);
+    ///
+    /// let input = "!nv4lid";
+    /// let invalid: Result<ExecDProgramOutputKey, _> = input.parse();
+    /// assert!(invalid.is_err());
+    /// ```
+    ExecDProgramOutputKey,
+    ExecDProgramOutputKeyError,
+    r"^[A-Za-z0-9_-]+$"
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exec_d_program_output_key_validation_valid() {
+        assert!("FOO".parse::<ExecDProgramOutputKey>().is_ok());
+        assert!("foo".parse::<ExecDProgramOutputKey>().is_ok());
+        assert!("FOO_BAR".parse::<ExecDProgramOutputKey>().is_ok());
+        assert!("foo_bar".parse::<ExecDProgramOutputKey>().is_ok());
+        assert!("123".parse::<ExecDProgramOutputKey>().is_ok());
+        assert!("FOO-bar".parse::<ExecDProgramOutputKey>().is_ok());
+        assert!("foo-BAR".parse::<ExecDProgramOutputKey>().is_ok());
+    }
+
+    #[test]
+    fn exec_d_program_output_key_validation_invalid() {
+        assert_eq!(
+            "FOO BAR".parse::<ExecDProgramOutputKey>(),
+            Err(ExecDProgramOutputKeyError::InvalidValue(String::from(
+                "FOO BAR"
+            )))
+        );
+
+        assert_eq!(
+            "FÜCHSCHEN".parse::<ExecDProgramOutputKey>(),
+            Err(ExecDProgramOutputKeyError::InvalidValue(String::from(
+                "FÜCHSCHEN"
+            )))
+        );
+
+        assert_eq!(
+            "🦊".parse::<ExecDProgramOutputKey>(),
+            Err(ExecDProgramOutputKeyError::InvalidValue(String::from("🦊")))
+        );
+
+        assert_eq!(
+            "".parse::<ExecDProgramOutputKey>(),
+            Err(ExecDProgramOutputKeyError::InvalidValue(String::new()))
+        );
+    }
+}

--- a/libcnb-data/src/lib.rs
+++ b/libcnb-data/src/lib.rs
@@ -13,6 +13,7 @@ pub mod build;
 pub mod build_plan;
 pub mod buildpack;
 pub mod buildpack_plan;
+pub mod exec_d;
 pub mod launch;
 pub mod layer;
 pub mod layer_content_metadata;

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -54,7 +54,7 @@ macro_rules! libcnb_newtype {
         $error_name:ident,
         $regex:expr
     ) => {
-        #[derive(Debug, Eq, PartialEq, ::serde::Serialize, Clone)]
+        #[derive(Debug, Eq, PartialEq, ::serde::Serialize, Clone, Hash)]
         $(#[$type_attributes])*
         pub struct $name(String);
 


### PR DESCRIPTION
Adds exec.d related types, these will be used to implement helpers for implementing exec.d programs with libcnb.

See: https://github.com/buildpacks/spec/blob/main/buildpack.md#execd

This isn't a breaking change since the existing `exec_d` module was never referenced in `lib.rs` and therefore neither exposed nor compiled.