### PR TITLE
Implement exec.d support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ members = [
     "libcnb-proc-macros",
     "libcnb-test",
     "examples/basics",
-    "examples/ruby-sample",
-    "examples/execd"
+    "examples/execd",
+    "examples/ruby-sample"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "libcnb-proc-macros",
     "libcnb-test",
     "examples/basics",
-    "examples/ruby-sample"
+    "examples/ruby-sample",
+    "examples/execd"
 ]

--- a/examples/execd/Cargo.toml
+++ b/examples/execd/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "examples-execd"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.56"
+
+[dependencies]
+libcnb = { path = "../../libcnb" }
+fastrand = "1.7.0"

--- a/examples/execd/Cargo.toml
+++ b/examples/execd/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examples-execd"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 
 [dependencies]
 libcnb = { path = "../../libcnb" }

--- a/examples/execd/Cargo.toml
+++ b/examples/execd/Cargo.toml
@@ -7,3 +7,6 @@ rust-version = "1.56"
 [dependencies]
 libcnb = { path = "../../libcnb" }
 fastrand = "1.7.0"
+
+[dev-dependencies]
+libcnb-test = { path = "../../libcnb-test" }

--- a/examples/execd/buildpack.toml
+++ b/examples/execd/buildpack.toml
@@ -1,0 +1,9 @@
+api = "0.6"
+
+[buildpack]
+id = "libcnb-examples/execd"
+version = "0.1.0"
+name = "Example libcnb buildpack: execd"
+
+[[stacks]]
+id = "*"

--- a/examples/execd/src/bin/dice_roller.rs
+++ b/examples/execd/src/bin/dice_roller.rs
@@ -4,8 +4,6 @@ use libcnb::exec_d::write_exec_d_program_output;
 use std::collections::HashMap;
 use std::iter;
 
-pub struct Env;
-
 pub fn main() {
     write_exec_d_program_output(env_vars());
 }

--- a/examples/execd/src/bin/dice_roller.rs
+++ b/examples/execd/src/bin/dice_roller.rs
@@ -1,0 +1,66 @@
+use libcnb::data::exec_d::ExecDProgramOutputKey;
+use libcnb::data::exec_d_program_output_key;
+use libcnb::exec_d::write_exec_d_program_output;
+use std::collections::HashMap;
+use std::iter;
+
+pub struct Env;
+
+pub fn main() {
+    write_exec_d_program_output(env_vars());
+}
+
+fn env_vars() -> HashMap<ExecDProgramOutputKey, String> {
+    HashMap::from([
+        (
+            exec_d_program_output_key!("ROLL_1D6"),
+            roll_dice(1, 6).to_string(),
+        ),
+        (
+            exec_d_program_output_key!("ROLL_4D6"),
+            roll_dice(4, 6).to_string(),
+        ),
+        (
+            exec_d_program_output_key!("ROLL_1D20"),
+            roll_dice(1, 20).to_string(),
+        ),
+    ])
+}
+
+fn roll_dice(amount: usize, sides: u32) -> u32 {
+    iter::repeat_with(|| fastrand::u32(1..=sides))
+        .take(amount)
+        .sum()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_roll_dice() {
+        assert!((1..=6).contains(&roll_dice(1, 6)));
+        assert!((8..=32).contains(&roll_dice(8, 4)));
+    }
+
+    #[test]
+    fn test_env_vars() {
+        let env_vars = env_vars();
+
+        let roll_1d6_value = env_vars
+            .get("ROLL_1D6")
+            .map(|value| value.parse::<u32>().unwrap());
+
+        let roll_4d6_value = env_vars
+            .get("ROLL_4D6")
+            .map(|value| value.parse::<u32>().unwrap());
+
+        let roll_1d20_value = env_vars
+            .get("ROLL_1D20")
+            .map(|value| value.parse::<u32>().unwrap());
+
+        assert!(roll_1d6_value.map_or(false, |value| (1..=6).contains(&value)));
+        assert!(roll_4d6_value.map_or(false, |value| (4..=32).contains(&value)));
+        assert!(roll_1d20_value.map_or(false, |value| (1..=20).contains(&value)));
+    }
+}

--- a/examples/execd/src/bin/dice_roller.rs
+++ b/examples/execd/src/bin/dice_roller.rs
@@ -1,3 +1,7 @@
+// Enable Clippy lints that are disabled by default.
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+
 use libcnb::data::exec_d::ExecDProgramOutputKey;
 use libcnb::data::exec_d_program_output_key;
 use libcnb::exec_d::write_exec_d_program_output;

--- a/examples/execd/src/layer.rs
+++ b/examples/execd/src/layer.rs
@@ -1,0 +1,35 @@
+use crate::ExecDBuildpack;
+use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::generic::GenericMetadata;
+use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+use libcnb::{additional_buildpack_binary_path, Buildpack};
+use std::path::Path;
+
+pub struct ExecDLayer;
+
+impl Layer for ExecDLayer {
+    type Buildpack = ExecDBuildpack;
+    type Metadata = GenericMetadata;
+
+    fn types(&self) -> LayerTypes {
+        LayerTypes {
+            launch: true,
+            build: false,
+            cache: false,
+        }
+    }
+
+    fn create(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        _layer_path: &Path,
+    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
+        LayerResultBuilder::new(GenericMetadata::default())
+            .exec_d_program(
+                "dice_roller",
+                additional_buildpack_binary_path!("dice_roller"),
+            )
+            .build()
+    }
+}

--- a/examples/execd/src/main.rs
+++ b/examples/execd/src/main.rs
@@ -1,0 +1,34 @@
+// Enable Clippy lints that are disabled by default.
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+// This lint is too noisy and enforces a style that reduces readability in many cases.
+#![allow(clippy::module_name_repetitions)]
+
+mod layer;
+
+use crate::layer::ExecDLayer;
+use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+use libcnb::data::layer_name;
+use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
+use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
+use libcnb::{buildpack_main, Buildpack};
+
+pub struct ExecDBuildpack;
+
+impl Buildpack for ExecDBuildpack {
+    type Platform = GenericPlatform;
+    type Metadata = GenericMetadata;
+    type Error = GenericError;
+
+    fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+        DetectResultBuilder::pass().build()
+    }
+
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+        context.handle_layer(layer_name!("layer_name"), ExecDLayer)?;
+
+        BuildResultBuilder::new().build()
+    }
+}
+
+buildpack_main!(ExecDBuildpack);

--- a/examples/execd/src/main.rs
+++ b/examples/execd/src/main.rs
@@ -8,7 +8,9 @@ mod layer;
 
 use crate::layer::ExecDLayer;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+use libcnb::data::launch::{Launch, ProcessBuilder};
 use libcnb::data::layer_name;
+use libcnb::data::process_type;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
@@ -27,7 +29,15 @@ impl Buildpack for ExecDBuildpack {
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         context.handle_layer(layer_name!("layer_name"), ExecDLayer)?;
 
-        BuildResultBuilder::new().build()
+        BuildResultBuilder::new()
+            .launch(
+                Launch::new().process(
+                    ProcessBuilder::new(process_type!("web"), "sleep 3600")
+                        .default(true)
+                        .build(),
+                ),
+            )
+            .build()
     }
 }
 

--- a/examples/execd/src/main.rs
+++ b/examples/execd/src/main.rs
@@ -31,6 +31,9 @@ impl Buildpack for ExecDBuildpack {
 
         BuildResultBuilder::new()
             .launch(
+                // Once https://github.com/Malax/libcnb.rs/issues/309 lands, this can be removed
+                // since we no longer need to have the default container process running for the
+                // duration of the test.
                 Launch::new().process(
                     ProcessBuilder::new(process_type!("web"), "sleep 3600")
                         .default(true)

--- a/examples/execd/tests/integration_test.rs
+++ b/examples/execd/tests/integration_test.rs
@@ -1,0 +1,24 @@
+//! Integration tests using libcnb-test.
+//!
+//! All integration tests are skipped by default (using the `ignore` attribute),
+//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+
+// Enable Clippy lints that are disabled by default.
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+
+use libcnb_test::IntegrationTest;
+
+#[test]
+#[ignore]
+fn basic() {
+    IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/empty-app").run_test(|context| {
+        context.start_container(&[], |container| {
+            let env_stdout = container.shell_exec("env").stdout;
+
+            assert!(env_stdout.contains("ROLL_1D6="));
+            assert!(env_stdout.contains("ROLL_4D6="));
+            assert!(env_stdout.contains("ROLL_1D20="));
+        });
+    });
+}

--- a/examples/execd/tests/integration_test.rs
+++ b/examples/execd/tests/integration_test.rs
@@ -7,7 +7,7 @@
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
 
-use libcnb_test::IntegrationTest;
+use libcnb_test::{assert_contains, IntegrationTest};
 
 #[test]
 #[ignore]
@@ -16,9 +16,9 @@ fn basic() {
         context.start_container(&[], |container| {
             let env_stdout = container.shell_exec("env").stdout;
 
-            assert!(env_stdout.contains("ROLL_1D6="));
-            assert!(env_stdout.contains("ROLL_4D6="));
-            assert!(env_stdout.contains("ROLL_1D20="));
+            assert_contains!(env_stdout, "ROLL_1D6=");
+            assert_contains!(env_stdout, "ROLL_4D6=");
+            assert_contains!(env_stdout, "ROLL_1D20=");
         });
     });
 }

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add `#[must_use]` to `DetectResult`, `DetectResultBuilder`, `PassDetectResultBuilder`, `FailDetectResultBuilder`, `BuildResult` and `BuildResultBuilder` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
 - Add `additional_buildpack_binary_path!` macro to resolve paths to additional buildpack binaries. Only works when the buildpack is packaged with `libcnb-cargo`/`libcnb-test`. ([#320](https://github.com/Malax/libcnb.rs/pull/320))
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
+- Add support for exec.d programs in layers. Use `LayerResultBuilder::exec_d_program` to add exec.d programs to a layer. ([#326](https://github.com/Malax/libcnb.rs/pull/326))
+- Add `libcnb::exec_d::write_exec_d_program_output` which writes `libcnb::data::exec_d::ExecDProgramOutput` in a spec conforming way. Use this to implement custom exec.d programs for your buildpack with libcnb.rs. ([#326](https://github.com/Malax/libcnb.rs/pull/326))
+- Add end-to-end example of a buildpacks that uses an exec.d program. ([#326](https://github.com/Malax/libcnb.rs/pull/326))
 
 ## [0.5.0] 2022-01-14
 

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -6,8 +6,7 @@
 - Add `additional_buildpack_binary_path!` macro to resolve paths to additional buildpack binaries. Only works when the buildpack is packaged with `libcnb-cargo`/`libcnb-test`. ([#320](https://github.com/Malax/libcnb.rs/pull/320))
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 - Add support for exec.d programs in layers. Use `LayerResultBuilder::exec_d_program` to add exec.d programs to a layer. ([#326](https://github.com/Malax/libcnb.rs/pull/326))
-- Add `libcnb::exec_d::write_exec_d_program_output` which writes `libcnb::data::exec_d::ExecDProgramOutput` in a spec conforming way. Use this to implement custom exec.d programs for your buildpack with libcnb.rs. ([#326](https://github.com/Malax/libcnb.rs/pull/326))
-- Add end-to-end example of a buildpacks that uses an exec.d program. ([#326](https://github.com/Malax/libcnb.rs/pull/326))
+- Add `libcnb::exec_d::write_exec_d_program_output` which writes `libcnb::data::exec_d::ExecDProgramOutput` in a spec conforming way. Use this to implement custom exec.d programs for your buildpack with libcnb.rs. (see [exec.d example](../examples/execd)) ([#326](https://github.com/Malax/libcnb.rs/pull/326))
 
 ## [0.5.0] 2022-01-14
 

--- a/libcnb/src/exec_d.rs
+++ b/libcnb/src/exec_d.rs
@@ -1,0 +1,25 @@
+use libcnb_data::exec_d::ExecDProgramOutput;
+use std::fs::File;
+use std::io::BufWriter;
+use std::io::Write;
+
+/// Writes the output of a CNB exec.d program in a spec compliant way.
+pub fn write_exec_d_program_output<O: Into<ExecDProgramOutput>>(o: O) {
+    // Allow compilation of exec.d programs under windows, but fail at runtime:
+    #[cfg(target_family = "windows")]
+    unimplemented!("libcnb.rs does not support running in Windows containers yet!");
+
+    #[cfg(target_family = "unix")]
+    {
+        use std::os::unix::io::FromRawFd;
+
+        // https://github.com/buildpacks/spec/blob/main/buildpack.md#execd
+        let output_file = unsafe { File::from_raw_fd(3) };
+
+        let serialized_output =
+            toml::to_string(&o.into()).expect("Could not TOML serialize exec.d program output: ");
+
+        write!(BufWriter::new(output_file), "{}", serialized_output)
+            .expect("Could not write exec.d program output: ");
+    }
+}

--- a/libcnb/src/exec_d.rs
+++ b/libcnb/src/exec_d.rs
@@ -19,7 +19,8 @@ pub fn write_exec_d_program_output<O: Into<ExecDProgramOutput>>(o: O) {
         let serialized_output =
             toml::to_string(&o.into()).expect("Could not TOML serialize exec.d program output: ");
 
-        write!(BufWriter::new(output_file), "{}", serialized_output)
+        BufWriter::new(output_file)
+            .write_all(serialized_output.as_bytes())
             .expect("Could not write exec.d program output: ");
     }
 }

--- a/libcnb/src/exec_d.rs
+++ b/libcnb/src/exec_d.rs
@@ -13,7 +13,13 @@ pub fn write_exec_d_program_output<O: Into<ExecDProgramOutput>>(o: O) {
     {
         use std::os::unix::io::FromRawFd;
 
+        // The spec requires writing the TOML to fd3:
         // https://github.com/buildpacks/spec/blob/main/buildpack.md#execd
+        //
+        // Using a file descriptor by id is an unsafe operation since Rust cannot guarantee it's
+        // actually mapped to something. Since we're implementing the CNB spec and it explicitly
+        // tells us to write to that file descriptor, this is safe to do without additional
+        // validation in this context.
         let output_file = unsafe { File::from_raw_fd(3) };
 
         let serialized_output =

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -258,10 +258,12 @@ fn write_layer<M: Serialize, P: AsRef<Path>>(
                 fs::remove_dir_all(&exec_d_dir)?;
             }
 
-            fs::create_dir_all(&exec_d_dir)?;
+            if !exec_d_programs.is_empty() {
+                fs::create_dir_all(&exec_d_dir)?;
 
-            for (name, path) in exec_d_programs {
-                fs::copy(path, exec_d_dir.join(name))?;
+                for (name, path) in exec_d_programs {
+                    fs::copy(path, exec_d_dir.join(name))?;
+                }
             }
         }
         ExecDPrograms::Keep => {}
@@ -395,6 +397,10 @@ mod tests {
         let layers_dir = temp_dir.path();
         let layer_dir = layers_dir.join(layer_name.as_str());
 
+        let execd_source_temp_dir = tempdir().unwrap();
+        let foo_execd_file = execd_source_temp_dir.path().join("foo");
+        fs::write(&foo_execd_file, "foo-contents").unwrap();
+
         super::write_layer(
             &layers_dir,
             &layer_name,
@@ -412,7 +418,7 @@ mod tests {
                 }),
                 metadata: GenericMetadata::default(),
             },
-            ExecDPrograms::Keep,
+            ExecDPrograms::Overwrite(HashMap::from([(String::from("foo"), foo_execd_file)])),
         )
         .unwrap();
 
@@ -421,6 +427,11 @@ mod tests {
         assert_eq!(
             fs::read_to_string(layer_dir.join("env/ENV_VAR.default")).unwrap(),
             "ENV_VAR_VALUE"
+        );
+
+        assert_eq!(
+            fs::read_to_string(layer_dir.join("exec.d/foo")).unwrap(),
+            "foo-contents"
         );
 
         let layer_content_metadata: LayerContentMetadata<GenericMetadata> =
@@ -442,6 +453,14 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let layers_dir = temp_dir.path();
         let layer_dir = layers_dir.join(layer_name.as_str());
+
+        let execd_source_temp_dir = tempdir().unwrap();
+        let foo_execd_file = execd_source_temp_dir.path().join("foo");
+        let bar_execd_file = execd_source_temp_dir.path().join("bar");
+        let baz_execd_file = execd_source_temp_dir.path().join("baz");
+        fs::write(&foo_execd_file, "foo-contents").unwrap();
+        fs::write(&bar_execd_file, "bar-contents").unwrap();
+        fs::write(&baz_execd_file, "baz-contents").unwrap();
 
         super::write_layer(
             &layers_dir,
@@ -467,7 +486,7 @@ mod tests {
                 }),
                 metadata: GenericMetadata::default(),
             },
-            ExecDPrograms::Keep,
+            ExecDPrograms::Overwrite(HashMap::from([(String::from("foo"), foo_execd_file)])),
         )
         .unwrap();
 
@@ -490,7 +509,10 @@ mod tests {
                 }),
                 metadata: GenericMetadata::default(),
             },
-            ExecDPrograms::Keep,
+            ExecDPrograms::Overwrite(HashMap::from([
+                (String::from("bar"), bar_execd_file),
+                (String::from("baz"), baz_execd_file),
+            ])),
         )
         .unwrap();
 
@@ -508,6 +530,18 @@ mod tests {
 
         assert!(!layer_dir.join("env/SOME_OTHER_ENV_VAR.default").exists());
 
+        assert!(!layer_dir.join("exec.d/foo").exists());
+
+        assert_eq!(
+            fs::read_to_string(layer_dir.join("exec.d/bar")).unwrap(),
+            "bar-contents"
+        );
+
+        assert_eq!(
+            fs::read_to_string(layer_dir.join("exec.d/baz")).unwrap(),
+            "baz-contents"
+        );
+
         let layer_content_metadata: LayerContentMetadata<GenericMetadata> =
             read_toml_file(layers_dir.join(format!("{layer_name}.toml"))).unwrap();
 
@@ -519,6 +553,137 @@ mod tests {
                 cache: true
             })
         );
+    }
+
+    #[test]
+    fn write_layer_keep_execd() {
+        let layer_name = layer_name!("foo");
+        let temp_dir = tempdir().unwrap();
+        let layers_dir = temp_dir.path();
+        let layer_dir = layers_dir.join(layer_name.as_str());
+
+        super::write_layer(
+            &layers_dir,
+            &layer_name,
+            &LayerEnv::new(),
+            &LayerContentMetadata {
+                types: Some(LayerTypes {
+                    launch: false,
+                    build: false,
+                    cache: true,
+                }),
+                metadata: GenericMetadata::default(),
+            },
+            ExecDPrograms::Keep,
+        )
+        .unwrap();
+
+        assert!(!layer_dir.join("exec.d").exists());
+    }
+
+    #[test]
+    fn write_existing_layer_keep_execd() {
+        let layer_name = layer_name!("foo");
+        let temp_dir = tempdir().unwrap();
+        let layers_dir = temp_dir.path();
+        let layer_dir = layers_dir.join(layer_name.as_str());
+
+        let execd_source_temp_dir = tempdir().unwrap();
+        let foo_execd_file = execd_source_temp_dir.path().join("foo");
+        fs::write(&foo_execd_file, "foo-contents").unwrap();
+
+        super::write_layer(
+            &layers_dir,
+            &layer_name,
+            &LayerEnv::new(),
+            &LayerContentMetadata {
+                types: Some(LayerTypes {
+                    launch: false,
+                    build: false,
+                    cache: true,
+                }),
+                metadata: GenericMetadata::default(),
+            },
+            ExecDPrograms::Overwrite(HashMap::from([(String::from("foo"), foo_execd_file)])),
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(layer_dir.join("exec.d/foo")).unwrap(),
+            "foo-contents"
+        );
+
+        super::write_layer(
+            &layers_dir,
+            &layer_name,
+            &LayerEnv::new(),
+            &LayerContentMetadata {
+                types: Some(LayerTypes {
+                    launch: false,
+                    build: false,
+                    cache: true,
+                }),
+                metadata: GenericMetadata::default(),
+            },
+            ExecDPrograms::Keep,
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(layer_dir.join("exec.d/foo")).unwrap(),
+            "foo-contents"
+        );
+    }
+
+    #[test]
+    fn write_existing_layer_overwrite_with_empty_execd() {
+        let layer_name = layer_name!("foo");
+        let temp_dir = tempdir().unwrap();
+        let layers_dir = temp_dir.path();
+        let layer_dir = layers_dir.join(layer_name.as_str());
+
+        let execd_source_temp_dir = tempdir().unwrap();
+        let foo_execd_file = execd_source_temp_dir.path().join("foo");
+        fs::write(&foo_execd_file, "foo-contents").unwrap();
+
+        super::write_layer(
+            &layers_dir,
+            &layer_name,
+            &LayerEnv::new(),
+            &LayerContentMetadata {
+                types: Some(LayerTypes {
+                    launch: false,
+                    build: false,
+                    cache: true,
+                }),
+                metadata: GenericMetadata::default(),
+            },
+            ExecDPrograms::Overwrite(HashMap::from([(String::from("foo"), foo_execd_file)])),
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(layer_dir.join("exec.d/foo")).unwrap(),
+            "foo-contents"
+        );
+
+        super::write_layer(
+            &layers_dir,
+            &layer_name,
+            &LayerEnv::new(),
+            &LayerContentMetadata {
+                types: Some(LayerTypes {
+                    launch: false,
+                    build: false,
+                    cache: true,
+                }),
+                metadata: GenericMetadata::default(),
+            },
+            ExecDPrograms::Overwrite(HashMap::new()),
+        )
+        .unwrap();
+
+        assert!(!layer_dir.join("exec.d").exists());
     }
 
     #[test]

--- a/libcnb/src/layer/public_interface.rs
+++ b/libcnb/src/layer/public_interface.rs
@@ -193,6 +193,23 @@ impl<M> LayerResultBuilder<M> {
         self
     }
 
+    /// Adds an exec.d program to the layer.
+    ///
+    /// # Example
+    ///
+    /// ```compile_fail
+    /// use libcnb::generic::GenericMetadata;
+    /// use libcnb::layer::LayerResultBuilder;
+    /// use libcnb::additional_buildpack_binary_path;
+    ///
+    /// LayerResultBuilder::new(GenericMetadata::default())
+    ///        .exec_d_program(
+    ///            "program_name_in_layer",
+    ///            // This does not compile in this doctest since there is no binary target with this name.
+    ///            additional_buildpack_binary_path!("binary_target_name"),
+    ///        )
+    ///        .build();
+    /// ```
     #[must_use]
     pub fn exec_d_program(
         mut self,

--- a/libcnb/src/layer/public_interface.rs
+++ b/libcnb/src/layer/public_interface.rs
@@ -6,6 +6,7 @@ use crate::layer_env::LayerEnv;
 use crate::Buildpack;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 /// Represents a buildpack layer written with the libcnb framework.
@@ -166,12 +167,14 @@ pub struct LayerData<M> {
 pub struct LayerResult<M> {
     pub metadata: M,
     pub env: Option<LayerEnv>,
+    pub exec_d_programs: HashMap<String, PathBuf>,
 }
 
 /// A builder that simplifies the creation of [`LayerResult`] values.
 pub struct LayerResultBuilder<M> {
     metadata: M,
     env: Option<LayerEnv>,
+    exec_d_programs: HashMap<String, PathBuf>,
 }
 
 impl<M> LayerResultBuilder<M> {
@@ -180,12 +183,24 @@ impl<M> LayerResultBuilder<M> {
         Self {
             metadata,
             env: None,
+            exec_d_programs: HashMap::new(),
         }
     }
 
     #[must_use]
     pub fn env(mut self, layer_env: LayerEnv) -> Self {
         self.env = Some(layer_env);
+        self
+    }
+
+    #[must_use]
+    pub fn exec_d_program(
+        mut self,
+        name: impl Into<String>,
+        exec_d_program: impl Into<PathBuf>,
+    ) -> Self {
+        self.exec_d_programs
+            .insert(name.into(), exec_d_program.into());
         self
     }
 
@@ -206,6 +221,7 @@ impl<M> LayerResultBuilder<M> {
         LayerResult {
             metadata: self.metadata,
             env: self.env,
+            exec_d_programs: self.exec_d_programs,
         }
     }
 }

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod build;
 pub mod detect;
+pub mod exec_d;
 pub mod generic;
 pub mod layer;
 pub mod layer_env;


### PR DESCRIPTION
Implements the last three remaining bits for exec.d support (#9). See related PRs for the other parts:

- #324 
- #320
- #314

## `exec_d` module

This module provides a helper that implements the non-data requirements for exec.d programs. The main part is writing to fd 3 which requires unsafe code. Typical usage looks like this:

```rust
pub fn main() {
    write_exec_d_program_output(HashMap::from([(
        exec_d_program_output_key!("ENV_VAR_ONE"),
        "some value",
    )]));
}
```

## `LayerResult`

`LayerResult` and `LayerResultBuilder` have been updated to allow adding exec.d programs to a layer in `Layer::create` and `Layer::update`. You add programs by giving them a name and a path from where to copy the binary from:

```rust
LayerResultBuilder::new(GenericMetadata::default())
            .exec_d_program(
                "dice_roller",
                additional_buildpack_binary_path!("dice_roller"),
            )
            .build()

```

##  Example using exec.d

Since using exec.d programs requires more than just invoking some new API, an example has been added that has an additional binary which sets up random environment variables with dice rolls. It demonstrates project setup, usage of `additional_buildpack_binary_path!`, the new `LayerResult` API and testing.

Closes #9, GUS-W-10670973, GUS-W-10670953