### PR TITLE
Upgrade to Clap v3

### DIFF
--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update cross-compile assistance on macOS to use https://github.com/messense/homebrew-macos-cross-toolchains instead of https://github.com/FiloSottile/homebrew-musl-cross. Support for the latter has not been removed, existing setups continue to work as before. ([#312](https://github.com/Malax/libcnb.rs/pull/312))
 - `libcnb-cargo` now cross-compiles and packages all binary targets of the buildpack. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/Malax/libcnb.rs/pull/314))
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
+- Upgrade CLI to Clap v3 ([#329](https://github.com/Malax/libcnb.rs/pull/329)).
 
 ## [0.2.1] 2022-01-19
 

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -17,7 +17,10 @@ path = "src/main.rs"
 
 [dependencies]
 cargo_metadata = "0.14.1"
-clap = "2.34.0"
+clap = { version = "3.1.0", default-features = false, features = [
+  "std",
+  "derive",
+] }
 fs_extra = "1.2.0"
 libcnb-data = { version = "0.4.0", path = "../libcnb-data" }
 log = "0.4.14"

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 cargo_metadata = "0.14.1"
-clap = { version = "3.1.0", default-features = false, features = [
+clap = { version = "3.1.1", default-features = false, features = [
   "std",
   "derive",
 ] }

--- a/libcnb-cargo/src/cli.rs
+++ b/libcnb-cargo/src/cli.rs
@@ -34,6 +34,7 @@ mod tests {
 
     #[test]
     fn verify_command() {
+        // Trigger Clap's internal assertions that validate the command configuration.
         Cli::command().debug_assert();
     }
 }

--- a/libcnb-cargo/src/cli.rs
+++ b/libcnb-cargo/src/cli.rs
@@ -1,35 +1,39 @@
-use clap::{App, AppSettings, Arg, SubCommand};
+use clap::{Parser, Subcommand};
 
-pub(crate) fn setup_cli_parsing<'a, 'b>() -> clap::App<'a, 'b> {
-    App::new(env!("CARGO_PKG_NAME"))
-        .bin_name("cargo")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about(env!("CARGO_PKG_DESCRIPTION"))
-        .setting(AppSettings::GlobalVersion)
-        .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(
-            SubCommand::with_name("libcnb")
-                .about("Allows working with buildpacks written with libcnb.rs")
-                .setting(AppSettings::SubcommandRequiredElseHelp)
-                .subcommand(
-                    SubCommand::with_name("package")
-                        .about("Packages a libcnb.rs Cargo project as a Cloud Native Buildpack")
-                        .arg(
-                            Arg::with_name("release")
-                                .long("release")
-                                .help("Build in release mode, with optimizations"),
-                        )
-                        .arg(
-                            Arg::with_name("target")
-                                .long("target")
-                                .default_value("x86_64-unknown-linux-musl")
-                                .help("Build for the target triple"),
-                        )
-                        .arg(
-                            Arg::with_name("no-cross-compile-assistance")
-                                .long("no-cross-compile-assistance")
-                                .help("Disable cross-compile assistance"),
-                        ),
-                ),
-        )
+#[derive(Parser)]
+#[clap(bin_name = "cargo")]
+pub(crate) enum Cli {
+    #[clap(subcommand)]
+    Libcnb(LibcnbSubcommand),
+}
+
+#[derive(Subcommand)]
+#[clap(version, about, long_about = None)]
+pub(crate) enum LibcnbSubcommand {
+    /// Packages a libcnb.rs Cargo project as a Cloud Native Buildpack
+    Package(PackageArgs),
+}
+
+#[derive(Parser)]
+pub(crate) struct PackageArgs {
+    /// Disable cross-compile assistance
+    #[clap(long)]
+    pub no_cross_compile_assistance: bool,
+    /// Build in release mode, with optimizations
+    #[clap(long)]
+    pub release: bool,
+    /// Build for the target triple
+    #[clap(long, default_value = "x86_64-unknown-linux-musl")]
+    pub target: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_command() {
+        Cli::command().debug_assert();
+    }
 }


### PR DESCRIPTION
And switch to Clap's new derive API.

See:
https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#300---2021-12-31
https://docs.rs/clap/latest/clap/#selecting-an-api
https://github.com/clap-rs/clap/blob/master/examples/tutorial_derive/README.md
https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md
https://github.com/clap-rs/clap/blob/master/examples/cargo-example-derive.md

Closes #246.
GUS-W-10726830.