### PR TITLE
Fix GitHub compare URLs in changelog

### DIFF
--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -49,23 +49,23 @@
 
 ## [0.3.0] 2021-09-17
 
-- See Git log: [v0.2.0...v0.3.0](https://github.com/Malax/libcnb.rs/compare/v0.2.0...v0.3.0)
+- See Git log: [libcnb/v0.2.0...libcnb/v0.3.0](https://github.com/Malax/libcnb.rs/compare/libcnb/v0.2.0...libcnb/v0.3.0)
 
 ## [0.2.0] 2021-08-31
 
-- See Git log: [v0.1.3...v0.2.0](https://github.com/Malax/libcnb.rs/compare/v0.1.3...v0.2.0)
+- See Git log: [libcnb/v0.1.3...libcnb/v0.2.0](https://github.com/Malax/libcnb.rs/compare/libcnb/v0.1.3...libcnb/v0.2.0)
 
 ## [0.1.3] 2021-08-06
 
-- See Git log: [v0.1.2...v0.1.3](https://github.com/Malax/libcnb.rs/compare/v0.1.2...v0.1.3)
+- See Git log: [libcnb/v0.1.2...libcnb/v0.1.3](https://github.com/Malax/libcnb.rs/compare/libcnb/v0.1.2...libcnb/v0.1.3)
 
 ## [0.1.2] 2021-08-06
 
-- See Git log: [v0.1.1...v0.1.2](https://github.com/Malax/libcnb.rs/compare/v0.1.1...v0.1.2)
+- See Git log: [libcnb/v0.1.1...libcnb/v0.1.2](https://github.com/Malax/libcnb.rs/compare/libcnb/v0.1.1...libcnb/v0.1.2)
 
 ## [0.1.1] 2021-05-26
 
-- See Git log: [v0.1.0...v0.1.1](https://github.com/Malax/libcnb.rs/compare/v0.1.0...v0.1.1)
+- See Git log: [libcnb/v0.1.0...libcnb/v0.1.1](https://github.com/Malax/libcnb.rs/compare/libcnb/v0.1.0...libcnb/v0.1.1)
 
 ## [0.1.0] 2021-03-18
 


### PR DESCRIPTION
Since the Git tag names have changed as part of #327.