### PR TITLE
Move changelog entry for #318 to the correct release

### DIFF
--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [Unreleased]
 
 - Add a `verify_bin_target_exists!` macro for verifying existence of binary targets in the current crate. ([#320](https://github.com/Malax/libcnb.rs/pull/320))
+- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 
 ## [0.1.1] 2022-01-14
 
 - Bump external dependency versions ([#233](https://github.com/Malax/libcnb.rs/pull/233) and [#275](https://github.com/Malax/libcnb.rs/pull/275)).
-- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 
 ## [0.1.0] 2021-12-08
 


### PR DESCRIPTION
The changelog entry for the `libcnb-proc-macros` part of #318 was added under the previous release section, rather than the "unreleased" section.