### PR TITLE
Remove import grouping

### DIFF
--- a/examples/ruby-sample/src/layers/bundler.rs
+++ b/examples/ruby-sample/src/layers/bundler.rs
@@ -1,15 +1,13 @@
-use crate::{util, RubyBuildpackError};
-use libcnb::data::layer_content_metadata::LayerTypes;
-use serde::Deserialize;
-use serde::Serialize;
-
-use std::path::Path;
-use std::process::Command;
-
 use crate::RubyBuildpack;
+use crate::{util, RubyBuildpackError};
 use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Env;
+use serde::Deserialize;
+use serde::Serialize;
+use std::path::Path;
+use std::process::Command;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct BundlerLayerMetadata {

--- a/examples/ruby-sample/src/layers/ruby.rs
+++ b/examples/ruby-sample/src/layers/ruby.rs
@@ -1,15 +1,12 @@
-use std::path::Path;
-
 use crate::util;
-
-use tempfile::NamedTempFile;
-
 use crate::{RubyBuildpack, RubyBuildpackError};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
+use std::path::Path;
+use tempfile::NamedTempFile;
 
 pub struct RubyLayer;
 

--- a/examples/ruby-sample/src/main.rs
+++ b/examples/ruby-sample/src/main.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use crate::layers::{BundlerLayer, RubyLayer};
+use crate::util::{DownloadError, UntarError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::launch::{Launch, ProcessBuilder};
 use libcnb::data::{layer_name, process_type};
@@ -12,8 +13,6 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
 use libcnb::layer_env::Scope;
 use libcnb::{buildpack_main, Buildpack};
-
-use crate::util::{DownloadError, UntarError};
 use serde::Deserialize;
 use std::process::ExitStatus;
 

--- a/libcnb-data/src/buildpack/api.rs
+++ b/libcnb-data/src/buildpack/api.rs
@@ -1,8 +1,7 @@
+use serde::Deserialize;
 use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::{Display, Formatter};
-
-use serde::Deserialize;
 
 /// The Buildpack API version.
 ///

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -6,11 +6,10 @@ mod version;
 
 pub use api::*;
 pub use id::*;
+use serde::Deserialize;
 pub use stack::*;
 pub use stack_id::*;
 pub use version::*;
-
-use serde::Deserialize;
 
 /// Data structures for the Buildpack descriptor (buildpack.toml).
 ///

--- a/libcnb-data/src/buildpack/stack.rs
+++ b/libcnb-data/src/buildpack/stack.rs
@@ -1,6 +1,5 @@
-use serde::Deserialize;
-
 use super::{StackId, StackIdError};
+use serde::Deserialize;
 
 // Used as a "shadow" struct to store
 // potentially invalid `Stack` data when deserializing

--- a/libcnb-data/src/buildpack/version.rs
+++ b/libcnb-data/src/buildpack/version.rs
@@ -1,9 +1,8 @@
+use fancy_regex::Regex;
+use serde::Deserialize;
 use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::{Display, Formatter};
-
-use fancy_regex::Regex;
-use serde::Deserialize;
 
 /// The Buildpack version.
 ///

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -14,12 +14,10 @@ mod pack;
 mod util;
 
 pub use crate::container_context::{ContainerContext, ContainerExecResult};
-
 use crate::pack::PackBuildCommand;
 use bollard::container::{Config, CreateContainerOptions, StartContainerOptions};
 use bollard::image::RemoveImageOptions;
 use bollard::Docker;
-
 use std::env;
 use std::env::VarError;
 use std::path::{Path, PathBuf};

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -1,7 +1,5 @@
 //! Provides build phase specific types and helpers.
 
-use std::path::PathBuf;
-
 use crate::buildpack::Buildpack;
 use crate::data::buildpack::StackId;
 use crate::data::layer::LayerName;
@@ -10,6 +8,7 @@ use crate::data::{
     buildpack::SingleBuildpackDescriptor, buildpack_plan::BuildpackPlan, launch::Launch,
 };
 use crate::layer::{HandleLayerErrorOrBuildpackError, Layer, LayerData};
+use std::path::PathBuf;
 
 /// Context for the build phase execution.
 pub struct BuildContext<B: Buildpack + ?Sized> {

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -1,11 +1,10 @@
 //! Provides detect phase specific types and helpers.
 
-use std::fmt::Debug;
-use std::path::PathBuf;
-
 use crate::buildpack::Buildpack;
 use crate::data::buildpack::StackId;
 use crate::{data::build_plan::BuildPlan, data::buildpack::SingleBuildpackDescriptor};
+use std::fmt::Debug;
+use std::path::PathBuf;
 
 /// Context for the detect phase execution.
 pub struct DetectContext<B: Buildpack + ?Sized> {

--- a/libcnb/src/generic.rs
+++ b/libcnb/src/generic.rs
@@ -1,10 +1,9 @@
 //! Generic implementations for some libcnb types.
 
-use std::path::Path;
-
 use crate::platform::Platform;
 use crate::{read_platform_env, Env};
 use std::fmt::{Debug, Display, Formatter};
+use std::path::Path;
 
 /// Generic TOML metadata.
 pub type GenericMetadata = Option<toml::value::Table>;

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -1,7 +1,6 @@
 use crate::build::BuildContext;
 use crate::data::layer::LayerName;
 use crate::data::layer_content_metadata::LayerContentMetadata;
-
 use crate::generic::GenericMetadata;
 use crate::layer::{ExistingLayerStrategy, Layer, LayerData, MetadataMigration};
 use crate::layer_env::LayerEnv;

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -1,13 +1,12 @@
 //! Type-safe, in-memory, layer environment variables.
 
+use crate::Env;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
 use std::fs;
 use std::path::Path;
-
-use crate::Env;
 
 /// Represents environment variable modifications of a Cloud Native Buildpack layer.
 ///

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -30,16 +30,14 @@ mod runtime;
 mod toml_file;
 mod util;
 
-#[doc(inline)]
-pub use libcnb_data as data;
-
+pub use buildpack::Buildpack;
 pub use env::*;
 pub use error::*;
+#[doc(inline)]
+pub use libcnb_data as data;
 pub use platform::*;
-pub use toml_file::*;
-
-pub use buildpack::Buildpack;
 pub use runtime::libcnb_runtime;
+pub use toml_file::*;
 
 const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =
     data::buildpack::BuildpackApi { major: 0, minor: 6 };

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -1,11 +1,3 @@
-use std::env;
-use std::ffi::OsStr;
-use std::path::{Path, PathBuf};
-use std::process;
-use std::process::exit;
-
-use serde::de::DeserializeOwned;
-
 use crate::build::{BuildContext, InnerBuildResult};
 use crate::buildpack::Buildpack;
 use crate::data::buildpack::{SingleBuildpackDescriptor, StackId};
@@ -14,7 +6,13 @@ use crate::error::Error;
 use crate::platform::Platform;
 use crate::toml_file::{read_toml_file, write_toml_file};
 use crate::LIBCNB_SUPPORTED_BUILDPACK_API;
+use serde::de::DeserializeOwned;
+use std::env;
+use std::ffi::OsStr;
 use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+use std::process;
+use std::process::exit;
 
 /// Main entry point for this framework.
 ///


### PR DESCRIPTION
After a discussion in https://github.com/Malax/libcnb.rs/pull/326#discussion_r808451189 and in Slack, we decided to remove all import grouping from libcnb code until `rustfmt` can properly enforce groupings and ordering within them.

As @edmorley said in our discussions, this is the least of the evils - at least `rustfmt` will order our imports now. But we will still have to enforce the "no groups" rule by hand. This isn't ideal, but the best we can do for now.