### PR TITLE
Bump minimum dependency versions

### DIFF
--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 [dependencies]
 flate2 = "1.0.22"
 libcnb = { path = "../../libcnb" }
-serde = "1.0.133"
-sha2 = "0.10.1"
+serde = "1.0.136"
+sha2 = "0.10.2"
 tar = "0.4.38"
 tempfile = "3.3.0"
 ureq = "2.4.0"

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -16,7 +16,7 @@ name = "cargo-libcnb"
 path = "src/main.rs"
 
 [dependencies]
-cargo_metadata = "0.14.1"
+cargo_metadata = "0.14.2"
 clap = { version = "3.1.1", default-features = false, features = [
   "std",
   "derive",
@@ -28,4 +28,4 @@ pathdiff = "0.2.1"
 size_format = "1.0.2"
 stderrlog = "0.5.1"
 toml = "0.5.8"
-which = "4.2.2"
+which = "4.2.4"

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -14,9 +14,9 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 [dependencies]
 fancy-regex = "0.8.0"
 libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.1.1" }
-serde = { version = "1.0.133", features = ["derive"] }
+serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"
 
 [dev-dependencies]
-serde_test = "1.0.133"
+serde_test = "1.0.136"

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 proc-macro = true
 
 [dependencies]
-cargo_metadata = "0.14.1"
+cargo_metadata = "0.14.2"
 fancy-regex = "0.8.0"
-quote = "1.0.14"
-syn = { version = "1.0.85", features = ["full"] }
+quote = "1.0.15"
+syn = { version = "1.0.86", features = ["full"] }

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -13,10 +13,10 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
 bollard = { version = "0.11.1", features = ["ssl"] }
-cargo_metadata = "0.14.1"
+cargo_metadata = "0.14.2"
 fastrand = "1.7.0"
 fs_extra = "1.2.0"
 libcnb-cargo = { path = "../libcnb-cargo", version = "0.2.1" }
 tempfile = "3.3.0"
-tokio = "1.15.0"
+tokio = "1.17.0"
 tokio-stream = "0.1.8"

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -12,10 +12,10 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
-anyhow = { version = "1.0.52", optional = true }
+anyhow = { version = "1.0.55", optional = true }
 libcnb-data = { path = "../libcnb-data", version = "0.4.0" }
 libcnb-proc-macros = { version = "0.1.1", path = "../libcnb-proc-macros" }
-serde = { version = "1.0.133", features = ["derive"] }
+serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"
 


### PR DESCRIPTION
In preparation for the next release.

Generated by `cargo upgrade --workspace`:
https://github.com/killercup/cargo-edit#cargo-upgrade