### PR TITLE
Allow setting environment variables in integration tests

### DIFF
--- a/examples/execd/tests/integration_test.rs
+++ b/examples/execd/tests/integration_test.rs
@@ -13,7 +13,7 @@ use libcnb_test::{assert_contains, IntegrationTest};
 #[ignore]
 fn basic() {
     IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/empty-app").run_test(|context| {
-        context.start_container(&[], |container| {
+        context.prepare_container().start(|container| {
             let env_stdout = container.shell_exec("env").stdout;
 
             assert_contains!(env_stdout, "ROLL_1D6=");

--- a/examples/ruby-sample/test-fixtures/simple-ruby-app/app.rb
+++ b/examples/ruby-sample/test-fixtures/simple-ruby-app/app.rb
@@ -1,6 +1,9 @@
 require 'socket'
 
-server = TCPServer.new(12345)
+port = ENV["PORT"]
+port = 12345 if port.nil?
+
+server = TCPServer.new(port)
 
 loop do
   socket = server.accept

--- a/examples/ruby-sample/tests/integration_test.rs
+++ b/examples/ruby-sample/tests/integration_test.rs
@@ -24,23 +24,26 @@ fn basic() {
             assert_contains!(context.pack_stdout, "---> Installing bundler");
             assert_contains!(context.pack_stdout, "---> Installing gems");
 
-            context.start_container(&[12345], |container| {
-                std::thread::sleep(Duration::from_secs(1));
+            context
+                .prepare_container()
+                .expose_port(12345)
+                .start(|container| {
+                    std::thread::sleep(Duration::from_secs(1));
 
-                assert_eq!(
-                    call_test_fixture_service(
-                        container.address_for_port(12345).unwrap(),
-                        "Hello World!"
-                    )
-                    .unwrap(),
-                    "!dlroW olleH"
-                );
+                    assert_eq!(
+                        call_test_fixture_service(
+                            container.address_for_port(12345).unwrap(),
+                            "Hello World!"
+                        )
+                        .unwrap(),
+                        "!dlroW olleH"
+                    );
 
-                assert_contains!(
-                    container.shell_exec("ruby --version").stdout,
-                    "ruby 2.7.0p0"
-                );
-            });
+                    assert_contains!(
+                        container.shell_exec("ruby --version").stdout,
+                        "ruby 2.7.0p0"
+                    );
+                });
         },
     );
 }

--- a/examples/ruby-sample/tests/integration_test.rs
+++ b/examples/ruby-sample/tests/integration_test.rs
@@ -26,13 +26,14 @@ fn basic() {
 
             context
                 .prepare_container()
-                .expose_port(12345)
+                .env("PORT", TEST_PORT.to_string())
+                .expose_port(TEST_PORT)
                 .start(|container| {
                     std::thread::sleep(Duration::from_secs(1));
 
                     assert_eq!(
                         call_test_fixture_service(
-                            container.address_for_port(12345).unwrap(),
+                            container.address_for_port(TEST_PORT).unwrap(),
                             "Hello World!"
                         )
                         .unwrap(),
@@ -61,3 +62,5 @@ where
 
     Ok(format!("{}", String::from_utf8_lossy(&buffer)))
 }
+
+const TEST_PORT: u16 = 12346;

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Add `IntegrationTest::env` and `IntegrationTest::envs`, allowing users to set environment variables for the build process. ([#346](https://github.com/Malax/libcnb.rs/pull/346))
+- Replaced `IntegrationTestContext::start_container` with `IntegrationTestContext::prepare_container`, allowing users to configure the container before starting it. Ports can now be exposed via `PrepareContainerContext::expose_port`. ([#346](https://github.com/Malax/libcnb.rs/pull/346))
+- Added the ability to set environment variables for the container via `PrepareContainerContext::env` and `PrepareContainerContext::envs`. ([#346](https://github.com/Malax/libcnb.rs/pull/346))
+
 ## [0.2.0] 2022-02-28
 
 - `libcnb-test` now cross-compiles and packages all binary targets of the buildpack for an integration test. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/Malax/libcnb.rs/pull/314))

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -29,7 +29,7 @@ fn test() {
             assert_contains!(context.pack_stdout, "---> Installing Maven");
             assert_contains!(context.pack_stdout, "---> Running mvn package");
 
-            context.start_container(&[12345], |container| {
+            context.prepare_container().expose_port(12345).start(|container| {
                 assert_eq!(
                     call_test_fixture_service(
                         container.address_for_port(12345).unwrap(),

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -33,12 +33,40 @@ impl<'a> PrepareContainerContext<'a> {
     }
 
     /// Inserts or updates an environment variable mapping for the container.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::IntegrationTest;
+    ///
+    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app").run_test(|context| {
+    ///     context
+    ///         .prepare_container()
+    ///         .env("FOO", "FOO_VALUE")
+    ///         .start(|container| {
+    ///             // ...
+    ///         })
+    /// });
+    /// ```
     pub fn env(&mut self, key: impl Into<String>, value: impl Into<String>) -> &mut Self {
         self.env.insert(key.into(), value.into());
         self
     }
 
     /// Adds or updates multiple environment variable mappings for the container.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::IntegrationTest;
+    ///
+    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app").run_test(|context| {
+    ///     context
+    ///         .prepare_container()
+    ///         .envs(vec![("FOO", "FOO_VALUE"), ("BAR", "BAR_VALUE")])
+    ///         .start(|container| {
+    ///             // ...
+    ///         })
+    /// });
+    /// ```
     pub fn envs<K: Into<String>, V: Into<String>, I: IntoIterator<Item = (K, V)>>(
         &mut self,
         envs: I,

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -1,9 +1,77 @@
-use crate::container_port_mapping;
 use crate::IntegrationTestContext;
-use bollard::container::{LogOutput, RemoveContainerOptions};
+use crate::{container_port_mapping, util};
+use bollard::container::{
+    Config, CreateContainerOptions, LogOutput, RemoveContainerOptions, StartContainerOptions,
+};
 use bollard::exec::{CreateExecOptions, StartExecResults};
 use std::net::SocketAddr;
 use tokio_stream::StreamExt;
+
+pub struct PrepareContainerContext<'a> {
+    integration_test_context: &'a IntegrationTestContext<'a>,
+    exposed_ports: Vec<u16>,
+}
+
+impl<'a> PrepareContainerContext<'a> {
+    pub(crate) fn new(integration_test_context: &'a IntegrationTestContext) -> Self {
+        Self {
+            integration_test_context,
+            exposed_ports: Vec::new(),
+        }
+    }
+
+    /// Exposes a given port of the container to the host machine.
+    ///
+    /// The given `exposed_port` is mapped to random ports on the host machine. Use
+    /// [`ContainerContext::address_for_port`] to obtain the local port for a mapped port.
+    pub fn expose_port(&mut self, port: u16) -> &mut Self {
+        self.exposed_ports.push(port);
+        self
+    }
+
+    /// Creates and starts the container configured by this context.
+    ///
+    /// # Panics
+    /// - When the container could not be created
+    /// - When the container could not be started
+    pub fn start<F: FnOnce(ContainerContext)>(&self, f: F) {
+        let container_name = util::random_docker_identifier();
+
+        self.integration_test_context
+            .integration_test
+            .tokio_runtime
+            .block_on(async {
+                self.integration_test_context
+                    .integration_test
+                    .docker
+                    .create_container(
+                        Some(CreateContainerOptions {
+                            name: container_name.clone(),
+                        }),
+                        Config {
+                            image: Some(self.integration_test_context.image_name.clone()),
+                            ..container_port_mapping::port_mapped_container_config(
+                                &self.exposed_ports,
+                            )
+                        },
+                    )
+                    .await
+                    .expect("Could not create container");
+
+                self.integration_test_context
+                    .integration_test
+                    .docker
+                    .start_container(&container_name, None::<StartContainerOptions<String>>)
+                    .await
+                    .expect("Could not start container");
+            });
+
+        f(ContainerContext {
+            container_name,
+            integration_test_context: self.integration_test_context,
+        });
+    }
+}
 
 pub struct ContainerContext<'a> {
     pub container_name: String,

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -25,7 +25,7 @@ impl<'a> PrepareContainerContext<'a> {
 
     /// Exposes a given port of the container to the host machine.
     ///
-    /// The given `exposed_port` is mapped to random ports on the host machine. Use
+    /// The given port is mapped to a random port on the host machine. Use
     /// [`ContainerContext::address_for_port`] to obtain the local port for a mapped port.
     pub fn expose_port(&mut self, port: u16) -> &mut Self {
         self.exposed_ports.push(port);

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -14,8 +14,9 @@ mod macros;
 mod pack;
 mod util;
 
-use crate::container_context::PrepareContainerContext;
-pub use crate::container_context::{ContainerContext, ContainerExecResult};
+pub use crate::container_context::{
+    ContainerContext, ContainerExecResult, PrepareContainerContext,
+};
 use crate::pack::PackBuildCommand;
 use bollard::image::RemoveImageOptions;
 use bollard::Docker;

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -135,14 +135,14 @@ impl IntegrationTest {
         self
     }
 
-    /// Adds an environment variable for the build process.
+    /// Inserts or updates an environment variable mapping for the build process.
     ///
     /// Note: This does not set this environment variable for running containers, it's only
     /// available during the build.
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{IntegrationTest, assert_contains};
+    /// use libcnb_test::IntegrationTest;
     ///
     /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app")
     ///     .env("ENV_VAR_ONE", "VALUE ONE")
@@ -153,6 +153,32 @@ impl IntegrationTest {
     /// ```
     pub fn env(&mut self, k: impl Into<String>, v: impl Into<String>) -> &mut Self {
         self.env.insert(k.into(), v.into());
+        self
+    }
+
+    /// Adds or updates multiple environment variable mappings for the build process.
+    ///
+    /// Note: This does not set environment variables for running containers, they're only
+    /// available during the build.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::IntegrationTest;
+    ///
+    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app")
+    ///     .envs(vec![("ENV_VAR_ONE", "VALUE ONE"), ("ENV_VAR_TWO", "SOME OTHER VALUE")])
+    ///     .run_test(|context| {
+    ///         // ...
+    ///     })
+    /// ```
+    pub fn envs<K: Into<String>, V: Into<String>, I: IntoIterator<Item = (K, V)>>(
+        &mut self,
+        envs: I,
+    ) -> &mut Self {
+        envs.into_iter().for_each(|(key, value)| {
+            self.env(key.into(), value.into());
+        });
+
         self
     }
 

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
@@ -10,7 +10,7 @@ pub(crate) struct PackBuildCommand {
     path: PathBuf,
     image_name: String,
     buildpacks: Vec<BuildpackReference>,
-    env: HashMap<String, String>,
+    env: BTreeMap<String, String>,
     verbose: bool,
 }
 
@@ -49,7 +49,7 @@ impl PackBuildCommand {
             path: path.into(),
             image_name: image_name.into(),
             buildpacks: vec![],
-            env: HashMap::new(),
+            env: BTreeMap::new(),
             verbose: false,
         }
     }
@@ -121,7 +121,7 @@ mod tests {
                 BuildpackReference::Id(String::from("libcnb/buildpack1")),
                 BuildpackReference::Path(PathBuf::from("/tmp/buildpack2")),
             ],
-            env: HashMap::from([
+            env: BTreeMap::from([
                 (String::from("ENV_FOO"), String::from("FOO_VALUE")),
                 (String::from("ENV_BAR"), String::from("WHITESPACE VALUE")),
             ]),
@@ -146,9 +146,9 @@ mod tests {
                 "--buildpack",
                 "/tmp/buildpack2",
                 "--env",
-                "ENV_FOO=FOO_VALUE",
-                "--env",
                 "ENV_BAR=WHITESPACE VALUE",
+                "--env",
+                "ENV_FOO=FOO_VALUE",
                 "-v"
             ]
         );


### PR DESCRIPTION
Adds the ability to set environment variables in `libcnb-test` integration tests for both build and runtime.

This allows us to write integration tests for code paths that are triggered by environment variables. For build-time, this is a non-breaking change since `IntegrationTest` already used a builder-like pattern:

```rust
IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/empty-app")
    .env("FOO", "SOME_VALUE")
    .run_test(|context| {
        // ...
    });
```

For runtime, `start_container` was replaced by `prepare_container` which is now also a builder-like structure. Besides allowing for future expansion when we want to set additional metadata for the container, exposing ports is now optional (users were previously forced to pass at least an empty array to `start_container`):

```rust
context
    .prepare_container()
    .env("PORT", TEST_PORT.to_string())
    .expose_port(TEST_PORT)
    .start(|container| {
      // ...
    });
```

Fixes https://github.com/Malax/libcnb.rs/issues/338, GUS-W-10765593