### PR TITLE
Fail tests early if cross-compilation toolchains are missing

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `libcnb-test` now cross-compiles and packages all binary targets of the buildpack for an integration test. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/Malax/libcnb.rs/pull/314))
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 - Add `assert_contains!` macro for easier matching of `pack` output in integration tests. ([#322](https://github.com/Malax/libcnb.rs/pull/322))
+- Fail tests early with a clearer error message, if expected cross-compilation toolchains are not found ([#347](https://github.com/Malax/libcnb.rs/pull/347).
 
 ## [0.1.1] 2022-02-04
 

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -19,8 +19,13 @@ pub(crate) fn package_crate_buildpack(
         .map_err(PackageCrateBuildpackError::CargoMetadataError)?;
 
     let cargo_env = match cross_compile_assistance(target_triple.as_ref()) {
+        CrossCompileAssistance::HelpText(help_text) => {
+            return Err(PackageCrateBuildpackError::CrossCompileConfigurationError(
+                help_text,
+            ));
+        }
+        CrossCompileAssistance::NoAssistance => Vec::new(),
         CrossCompileAssistance::Configuration { cargo_env } => cargo_env,
-        _ => vec![],
     };
 
     let buildpack_dir =
@@ -47,9 +52,10 @@ pub(crate) fn package_crate_buildpack(
 
 #[derive(Debug)]
 pub(crate) enum PackageCrateBuildpackError {
-    CannotCreateBuildpackTempDirectory(std::io::Error),
     BuildBinariesError(BuildBinariesError),
     CannotAssembleBuildpackDirectory(std::io::Error),
+    CannotCreateBuildpackTempDirectory(std::io::Error),
     CannotDetermineCrateDirectory(std::env::VarError),
     CargoMetadataError(cargo_metadata::Error),
+    CrossCompileConfigurationError(String),
 }


### PR DESCRIPTION
For platforms where the cross-compilation assistance feature knows which tools are required, tests will now fail early with a clearer error message if those tools are not found. This brings `libcnb-test` in line with the implementation of `cargo libcnb package`.

For example:

```
$ cargo test basic -- --ignored
test basic ... FAILED

failures:

---- basic stdout ----
thread 'basic' panicked at 'Could not package current crate as buildpack: CrossCompileConfigurationError("For cross-compilation from macOS to x86_64-unknown-linux-musl, a C compiler and\nlinker for the target platform must be installed on your computer.\n\nThe easiest way to install the required cross-compilation toolchain is to run:\nbrew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl\n\nFor more information, see:\nhttps://github.com/messense/homebrew-macos-cross-toolchains")', /Users/emorley/src/libcnb.rs/libcnb-test/src/lib.rs:177:22
```

The output does contain escaped newlines which is not ideal - however so will many other build related failure modes, since `IntegrationTest::run_test()` uses `.expect()` throughout (which prints the debug representation of any returned `Error`s) and improving that is outside the scope of this issue.

Fixes #340.
GUS-W-10736094.