### PR TITLE
Derive `Default` instead of implementing manually

### DIFF
--- a/libcnb-data/src/build_plan.rs
+++ b/libcnb-data/src/build_plan.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use std::collections::VecDeque;
 use toml::value::Table;
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Default)]
 #[must_use]
 pub struct BuildPlan {
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -15,20 +15,11 @@ pub struct BuildPlan {
 
 impl BuildPlan {
     pub fn new() -> Self {
-        Self {
-            provides: vec![],
-            requires: vec![],
-            or: vec![],
-        }
+        Self::default()
     }
 }
 
-impl Default for BuildPlan {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
+#[derive(Default)]
 #[must_use]
 pub struct BuildPlanBuilder {
     acc: VecDeque<(Vec<Provide>, Vec<Require>)>,
@@ -38,11 +29,7 @@ pub struct BuildPlanBuilder {
 
 impl BuildPlanBuilder {
     pub fn new() -> Self {
-        Self {
-            acc: VecDeque::new(),
-            current_provides: vec![],
-            current_requires: vec![],
-        }
+        Self::default()
     }
 
     pub fn provides(mut self, name: impl AsRef<str>) -> Self {
@@ -83,12 +70,6 @@ impl BuildPlanBuilder {
         } else {
             BuildPlan::new()
         }
-    }
-}
-
-impl Default for BuildPlanBuilder {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -2,7 +2,7 @@ use crate::bom;
 use crate::newtypes::libcnb_newtype;
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Launch {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -33,24 +33,13 @@ pub struct Launch {
 impl Launch {
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            bom: bom::Bom::new(),
-            labels: Vec::new(),
-            processes: Vec::new(),
-            slices: Vec::new(),
-        }
+        Self::default()
     }
 
     #[must_use]
     pub fn process(mut self, process: Process) -> Self {
         self.processes.push(process);
         self
-    }
-}
-
-impl Default for Launch {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -143,6 +143,7 @@ pub(crate) enum InnerBuildResult {
 ///    .launch(Launch::new().process(ProcessBuilder::new(process_type!("type"), "command").arg("-v").build()))
 ///    .build();
 /// ```
+#[derive(Default)]
 #[must_use]
 pub struct BuildResultBuilder {
     launch: Option<Launch>,
@@ -151,10 +152,7 @@ pub struct BuildResultBuilder {
 
 impl BuildResultBuilder {
     pub fn new() -> Self {
-        Self {
-            launch: None,
-            store: None,
-        }
+        Self::default()
     }
 
     /// Builds the final [`BuildResult`].
@@ -183,11 +181,5 @@ impl BuildResultBuilder {
     pub fn store(mut self, store: Store) -> Self {
         self.store = Some(store);
         self
-    }
-}
-
-impl Default for BuildResultBuilder {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/libcnb/src/env.rs
+++ b/libcnb/src/env.rs
@@ -25,7 +25,7 @@ use std::ffi::{OsStr, OsString};
 ///     String::from_utf8_lossy(&output.stdout)
 /// );
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Env {
     inner: HashMap<OsString, OsString>,
 }
@@ -46,9 +46,7 @@ impl Env {
     /// Creates an empty `Env` struct.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            inner: HashMap::new(),
-        }
+        Self::default()
     }
 
     /// Inserts a key-value pair into the environment, overriding the value if `key` was already
@@ -73,12 +71,6 @@ impl Env {
     #[must_use]
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, OsString, OsString> {
         self.inner.iter()
-    }
-}
-
-impl Default for Env {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -79,7 +79,7 @@ use std::path::Path;
 /// assert_eq!(env.get("PATH").unwrap(), layer_dir.join("bin"));
 /// assert_eq!(env.get("CPATH"), None); // None, because CPATH is only added during build
 /// ```
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Default, Clone)]
 pub struct LayerEnv {
     all: LayerEnvDelta,
     build: LayerEnvDelta,
@@ -112,14 +112,7 @@ impl LayerEnv {
     /// ```
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            all: LayerEnvDelta::new(),
-            build: LayerEnvDelta::new(),
-            launch: LayerEnvDelta::new(),
-            process: HashMap::new(),
-            layer_paths_build: LayerEnvDelta::new(),
-            layer_paths_launch: LayerEnvDelta::new(),
-        }
+        Self::default()
     }
 
     /// Applies this [`LayerEnv`] to the given [`Env`] for the given [`Scope`].
@@ -381,12 +374,6 @@ impl LayerEnv {
     }
 }
 
-impl Default for LayerEnv {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Environment variable modification behavior.
 /// ([CNB spec: Environment Variable Modification Rules](https://github.com/buildpacks/spec/blob/main/buildpack.md#environment-variable-modification-rules))
 #[derive(Eq, PartialEq, Debug, Clone)]
@@ -431,16 +418,14 @@ pub enum Scope {
     Process(String),
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Default, Clone)]
 struct LayerEnvDelta {
     entries: BTreeMap<(ModificationBehavior, OsString), OsString>,
 }
 
 impl LayerEnvDelta {
     fn new() -> Self {
-        Self {
-            entries: BTreeMap::new(),
-        }
+        Self::default()
     }
 
     fn apply(&self, env: &Env) -> Env {


### PR DESCRIPTION
Switches any manual `Default` implementations to using `derive`, when the manual implementation was identical to that which would be automatically generated.

Spotted whilst looking into #295.