### PR TITLE
Prepare `0.6.0` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libcnb = "0.5.0"
+libcnb = "0.6.0"
 ```
 
 Since we're writing a Cloud Native Buildpack, we also need a `buildpack.toml`. Use the template below and write it to a

--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+## [0.3.0] 2022-02-28
+
 - Update cross-compile assistance on macOS to use https://github.com/messense/homebrew-macos-cross-toolchains instead of https://github.com/FiloSottile/homebrew-musl-cross. Support for the latter has not been removed, existing setups continue to work as before. ([#312](https://github.com/Malax/libcnb.rs/pull/312))
 - `libcnb-cargo` now cross-compiles and packages all binary targets of the buildpack. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/Malax/libcnb.rs/pull/314))
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 - Upgrade CLI to Clap v3 ([#329](https://github.com/Malax/libcnb.rs/pull/329)).
+- Update `libcnb-data` from `0.4.0` to `0.5.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#050-2022-02-28). ([#361](https://github.com/Malax/libcnb.rs/pull/361))
 
 ## [0.2.1] 2022-01-19
 

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-cargo"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -22,7 +22,7 @@ clap = { version = "3.1.1", default-features = false, features = [
   "derive",
 ] }
 fs_extra = "1.2.0"
-libcnb-data = { version = "0.4.0", path = "../libcnb-data" }
+libcnb-data = { version = "0.5.0", path = "../libcnb-data" }
 log = "0.4.14"
 pathdiff = "0.2.1"
 size_format = "1.0.2"

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+## [0.5.0] 2022-02-28
+
 - Add `#[must_use]` to `BuildPlan` and `BuildPlanBuilder` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
 - Add `exec_d` module with types representing the output of an `exec.d` program ([#324](https://github.com/Malax/libcnb.rs/pull/324)).
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 - Adjust newtype generated compile-time validation macros so that they don't also perform redundant validation at runtime. In cases where only compile-time validation is being performed (for example `exec.d` scripts), this results in a significant reduction in binary size. ([#331](https://github.com/Malax/libcnb.rs/pull/331))
+- Update `libcnb-proc-macros` from `0.1.1` to `0.2.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#020-2022-02-28). ([#361](https://github.com/Malax/libcnb.rs/pull/361))
 
 ## [0.4.0] 2022-01-14
 

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-data"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -13,7 +13,7 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
 fancy-regex = "0.8.0"
-libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.1.1" }
+libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.2.0" }
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"

--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.0] 2022-02-28
+
 - Add a `verify_bin_target_exists!` macro for verifying existence of binary targets in the current crate. ([#320](https://github.com/Malax/libcnb.rs/pull/320))
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-proc-macros"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+## [0.2.0] 2022-02-28
+
 - `libcnb-test` now cross-compiles and packages all binary targets of the buildpack for an integration test. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/Malax/libcnb.rs/pull/314))
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 - Add `assert_contains!` macro for easier matching of `pack` output in integration tests. ([#322](https://github.com/Malax/libcnb.rs/pull/322))
 - Fail tests early with a clearer error message, if expected cross-compilation toolchains are not found ([#347](https://github.com/Malax/libcnb.rs/pull/347).
+- Update `libcnb-cargo` from `0.2.1` to `0.3.0` - see the [libcnb-cargo changelog](../libcnb-cargo/CHANGELOG.md#030-2022-02-28). ([#361](https://github.com/Malax/libcnb.rs/pull/361))
 
 ## [0.1.1] 2022-02-04
 

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-test"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -16,7 +16,7 @@ bollard = { version = "0.11.1", features = ["ssl"] }
 cargo_metadata = "0.14.2"
 fastrand = "1.7.0"
 fs_extra = "1.2.0"
-libcnb-cargo = { path = "../libcnb-cargo", version = "0.2.1" }
+libcnb-cargo = { path = "../libcnb-cargo", version = "0.3.0" }
 tempfile = "3.3.0"
 tokio = "1.17.0"
 tokio-stream = "0.1.8"

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [Unreleased]
 
+## [0.6.0] 2022-02-28
+
 - Add `#[must_use]` to `DetectResult`, `DetectResultBuilder`, `PassDetectResultBuilder`, `FailDetectResultBuilder`, `BuildResult` and `BuildResultBuilder` ([#288](https://github.com/Malax/libcnb.rs/pull/288)).
 - Add `additional_buildpack_binary_path!` macro to resolve paths to additional buildpack binaries. Only works when the buildpack is packaged with `libcnb-cargo`/`libcnb-test`. ([#320](https://github.com/Malax/libcnb.rs/pull/320))
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/Malax/libcnb.rs/pull/318)).
 - Add support for exec.d programs in layers. Use `LayerResultBuilder::exec_d_program` to add exec.d programs to a layer. ([#326](https://github.com/Malax/libcnb.rs/pull/326))
 - Add `libcnb::exec_d::write_exec_d_program_output` which writes `libcnb::data::exec_d::ExecDProgramOutput` in a spec conforming way. Use this to implement custom exec.d programs for your buildpack with libcnb.rs. (see [exec.d example](../examples/execd)) ([#326](https://github.com/Malax/libcnb.rs/pull/326))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.4.0` to `0.5.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#050-2022-02-28). ([#361](https://github.com/Malax/libcnb.rs/pull/361))
+- Update `libcnb-proc-macros` from `0.1.1` to `0.2.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#020-2022-02-28). ([#361](https://github.com/Malax/libcnb.rs/pull/361))
 
 ## [0.5.0] 2022-01-14
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -13,8 +13,8 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
 anyhow = { version = "1.0.55", optional = true }
-libcnb-data = { path = "../libcnb-data", version = "0.4.0" }
-libcnb-proc-macros = { version = "0.1.1", path = "../libcnb-proc-macros" }
+libcnb-data = { path = "../libcnb-data", version = "0.5.0" }
+libcnb-proc-macros = { version = "0.2.0", path = "../libcnb-proc-macros" }
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"


### PR DESCRIPTION
Refer to https://github.com/Malax/libcnb.rs/issues/335, all crates have breaking changes due to the MSRV bump from https://github.com/Malax/libcnb.rs/pull/318.

Closes GUS-W-10765814