### PR TITLE
Fix compilation on non-`unix` family systems

### DIFF
--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -494,9 +494,15 @@ impl LayerEnvDelta {
             // explicitly written in the spec, we read through the the reference implementation and
             // determined that it also treats the file contents as raw bytes.
             // See: https://github.com/buildpacks/lifecycle/blob/a7428a55c2a14d8a37e84285b95dc63192e3264e/env/env.go#L73-L106
-            use std::os::unix::ffi::OsStringExt;
             let path = dir_entry?.path();
-            let file_contents = OsString::from_vec(fs::read(&path)?);
+
+            #[cfg(target_family = "unix")]
+            let file_contents = {
+                use std::os::unix::ffi::OsStringExt;
+                OsString::from_vec(fs::read(&path)?)
+            };
+            #[cfg(not(target_family = "unix"))]
+            let file_contents = OsString::from(&fs::read_to_string(&path)?);
 
             // Rely on the Rust standard library for splitting stem and extension. Since paths
             // are not necessarily UTF-8 encoded, this is not as trivial as it might look like.
@@ -533,8 +539,6 @@ impl LayerEnvDelta {
     }
 
     fn write_to_env_dir(&self, path: impl AsRef<Path>) -> Result<(), std::io::Error> {
-        use std::os::unix::ffi::OsStrExt;
-
         if path.as_ref().exists() {
             // This is a possible race condition if the path is deleted between the check and
             // removal by this code. We accept this for now to keep it simple.
@@ -557,7 +561,14 @@ impl LayerEnvDelta {
 
             let file_path = path.as_ref().join(file_name);
 
-            fs::write(file_path, &value.as_bytes())?;
+            #[cfg(target_family = "unix")]
+            {
+                use std::os::unix::ffi::OsStrExt;
+                fs::write(file_path, &value.as_bytes())?;
+            }
+
+            #[cfg(not(target_family = "unix"))]
+            fs::write(file_path, &value.to_string_lossy().as_bytes())?;
         }
 
         Ok(())

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -54,7 +54,6 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
         .and_then(Path::file_name)
         .and_then(OsStr::to_str);
 
-    #[cfg(any(target_family = "unix"))]
     let result = match current_exe_file_name {
         Some("detect") => libcnb_runtime_detect(buildpack),
         Some("build") => libcnb_runtime_build(buildpack),


### PR DESCRIPTION
Previously, there were a couple of pieces of code that failed to compile on Windows e.g. `use std::os::unix::ffi::OsStringExt;`.

This PR adds `#[cfg(target_family = "unix")]` attributes to avoid those compile errors and where necessary implements analogous functionality for non-unix platforms (checked using cross-compile on Linux).

Note: This commit has been extracted out from https://github.com/Malax/libcnb.rs/pull/313 (which will be superseded by this an another PR).