### PR TITLE
Make `libcnb_runtime_detect` etc public

### DIFF
--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -37,7 +37,9 @@ pub use error::*;
 #[doc(inline)]
 pub use libcnb_data as data;
 pub use platform::*;
-pub use runtime::libcnb_runtime;
+pub use runtime::{
+    libcnb_runtime, libcnb_runtime_build, libcnb_runtime_detect, BuildArgs, DetectArgs,
+};
 pub use toml_file::*;
 
 const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -89,7 +89,7 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
     }
 }
 
-fn libcnb_runtime_detect<B: Buildpack>(
+pub fn libcnb_runtime_detect<B: Buildpack>(
     buildpack: &B,
     args: DetectArgs,
 ) -> crate::Result<i32, B::Error> {
@@ -125,7 +125,7 @@ fn libcnb_runtime_detect<B: Buildpack>(
     }
 }
 
-fn libcnb_runtime_build<B: Buildpack>(
+pub fn libcnb_runtime_build<B: Buildpack>(
     buildpack: &B,
     args: BuildArgs,
 ) -> crate::Result<i32, B::Error> {
@@ -170,13 +170,13 @@ fn libcnb_runtime_build<B: Buildpack>(
     }
 }
 
-struct DetectArgs {
+pub struct DetectArgs {
     pub platform_dir_path: PathBuf,
     pub build_plan_path: PathBuf,
 }
 
 impl DetectArgs {
-    fn parse(args: &[String]) -> Result<DetectArgs, &str> {
+    pub fn parse(args: &[String]) -> Result<DetectArgs, &str> {
         if let [_, platform_dir_path, build_plan_path] = args {
             Ok(DetectArgs {
                 platform_dir_path: PathBuf::from(platform_dir_path),
@@ -188,14 +188,14 @@ impl DetectArgs {
     }
 }
 
-struct BuildArgs {
+pub struct BuildArgs {
     pub layers_dir_path: PathBuf,
     pub platform_dir_path: PathBuf,
     pub buildpack_plan_path: PathBuf,
 }
 
 impl BuildArgs {
-    fn parse(args: &[String]) -> Result<BuildArgs, &str> {
+    pub fn parse(args: &[String]) -> Result<BuildArgs, &str> {
         if let [_, layers_dir_path, platform_dir_path, buildpack_plan_path] = args {
             Ok(BuildArgs {
                 layers_dir_path: PathBuf::from(layers_dir_path),


### PR DESCRIPTION
This allows reuse of these functions by other crates e.g other CLI tools that want to call `detect` and `build` methods on buildpacks.

Note: This commit is made on top of https://github.com/Malax/libcnb.rs/pull/369

Note: This commit has been extracted out from https://github.com/Malax/libcnb.rs/pull/313 (which will be superseded by this and other PRs).