### PR TITLE
Use `--pull-policy if-not-present` when running `pack build`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,6 @@ jobs:
         uses: Swatinem/rust-cache@v1.3.0
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v4.6.0
-      - name: Configure Pack CLI
-        # Default to a small non-libc image for faster CI + to validate the static musl cross-compilation.
-        # Adjust pull-policy to prevent redundant image-pulling, which slows CI and risks hitting registry rate limits.
-        run: |
-          pack config default-builder cnbs/sample-builder:alpine
-          pack config pull-policy if-not-present
       - name: Run integration tests
         # Runs any tests annotated with the `#[ignore]` attribute (which in this repo, are all of the integration tests).
         run: cargo test -- --ignored
@@ -73,4 +67,5 @@ jobs:
         run: cargo run --package libcnb-cargo -- libcnb package
         working-directory: ./examples/basics
       - name: Pack build using examples/basics
-        run: pack build example-basics --buildpack target/buildpack/debug/libcnb-examples_basics --path examples/
+        # Uses a non-libc image to validate the static musl cross-compilation.
+        run: pack build example-basics --builder cnbs/sample-builder:alpine --buildpack target/buildpack/debug/libcnb-examples_basics --path examples/

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Replaced `IntegrationTestContext::start_container` with `IntegrationTestContext::prepare_container`, allowing users to configure the container before starting it. Ports can now be exposed via `PrepareContainerContext::expose_port`. ([#346](https://github.com/Malax/libcnb.rs/pull/346))
 - Added the ability to set environment variables for the container via `PrepareContainerContext::env` and `PrepareContainerContext::envs`. ([#346](https://github.com/Malax/libcnb.rs/pull/346))
 - Switch from `libcnb-cargo` to the new `libcnb-package` crate for buildpack packaging, which improves compile times due to it not including CLI-related dependencies ([#362](https://github.com/Malax/libcnb.rs/pull/362)).
+- Use `--pull-policy if-not-present` when running `pack build` ([#373](https://github.com/Malax/libcnb.rs/pull/373)).
 
 ## [0.2.0] 2022-02-28
 

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -17,7 +17,7 @@ mod util;
 pub use crate::container_context::{
     ContainerContext, ContainerExecResult, PrepareContainerContext,
 };
-use crate::pack::PackBuildCommand;
+use crate::pack::{PackBuildCommand, PullPolicy};
 use bollard::image::RemoveImageOptions;
 use bollard::Docker;
 use std::collections::HashMap;
@@ -233,8 +233,13 @@ impl IntegrationTest {
 
         let image_name = util::random_docker_identifier();
 
-        let mut pack_command =
-            PackBuildCommand::new(&self.builder_name, temp_app_dir.path(), &image_name);
+        let mut pack_command = PackBuildCommand::new(
+            &self.builder_name,
+            temp_app_dir.path(),
+            &image_name,
+            // Prevent redundant image-pulling, which slows tests and risks hitting registry rate limits.
+            PullPolicy::IfNotPresent,
+        );
 
         self.env.iter().for_each(|(key, value)| {
             pack_command.env(key, value);

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -76,6 +76,9 @@ impl From<PackBuildCommand> for Command {
             pack_build_command.builder,
             String::from("--path"),
             pack_build_command.path.to_string_lossy().to_string(),
+            // Adjust pull-policy to prevent redundant image-pulling, which slows CI and risks hitting registry rate limits.
+            String::from("--pull-policy"),
+            String::from("if-not-present"),
         ];
 
         for buildpack in pack_build_command.buildpacks {
@@ -141,6 +144,8 @@ mod tests {
                 "builder:20",
                 "--path",
                 "/tmp/foo/bar",
+                "--pull-policy",
+                "if-not-present",
                 "--buildpack",
                 "libcnb/buildpack1",
                 "--buildpack",


### PR DESCRIPTION
Since it:
1. Saves ~2 seconds per integration test re-pulling an image that's already up to date.
2. Helps prevent hitting Docker Hub or ECR rate limits from duplicate (and redundant) image pulling (that counts agains the rate limit even when it's a no-op).

Longer term, if Pack CLI supports a periodic pulling mode (buildpacks/pack#1368), we can switch to that, however for now this is the lesser of two evils - and in most cases Pack usage outside of `libcnb-test` will ensure that newer builder images are pulled from time to time.

See #306 for more details.

See also:
https://buildpacks.io/docs/tools/pack/cli/pack_config_pull-policy/

Fixes #306.
GUS-W-10799284.