### PR TITLE
Make `libcnb_runtime_build` etc public

### DIFF
--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Allow compilation of libcnb.rs buildpacks on Windows. Please note that this does not imply Windows container support, it's meant to allow running unit tests without cross-compiling. ([#368](https://github.com/Malax/libcnb.rs/pull/368))
+- Expose `runtime::libcnb_runtime_detect`, `runtime::libcnb_runtime_build` and their related types for advanced use-cases. Buildpack authors should not use these. ([#375](https://github.com/Malax/libcnb.rs/pull/375)).
 
 ## [0.6.0] 2022-02-28
 

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -37,9 +37,7 @@ pub use error::*;
 #[doc(inline)]
 pub use libcnb_data as data;
 pub use platform::*;
-pub use runtime::{
-    libcnb_runtime, libcnb_runtime_build, libcnb_runtime_detect, BuildArgs, DetectArgs,
-};
+pub use runtime::*;
 pub use toml_file::*;
 
 const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -37,7 +37,9 @@ pub use error::*;
 #[doc(inline)]
 pub use libcnb_data as data;
 pub use platform::*;
-pub use runtime::libcnb_runtime;
+pub use runtime::{
+    libcnb_runtime, libcnb_runtime_build, libcnb_runtime_detect, BuildArgs, DetectArgs,
+};
 pub use toml_file::*;
 
 const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -96,6 +96,10 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
     }
 }
 
+/// Detect entry point for this framework.
+///
+/// Exposed only to allow for advanced use-cases where detect is programmatically invoked.
+#[doc(hidden)]
 pub fn libcnb_runtime_detect<B: Buildpack>(
     buildpack: &B,
     args: DetectArgs,
@@ -132,6 +136,10 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
     }
 }
 
+/// Build entry point for this framework.
+///
+/// Exposed only to allow for advanced use-cases where detect is programmatically invoked.
+#[doc(hidden)]
 pub fn libcnb_runtime_build<B: Buildpack>(
     buildpack: &B,
     args: BuildArgs,
@@ -177,6 +185,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     }
 }
 
+#[doc(hidden)]
 pub struct DetectArgs {
     pub platform_dir_path: PathBuf,
     pub build_plan_path: PathBuf,
@@ -196,10 +205,12 @@ impl DetectArgs {
 }
 
 #[derive(Debug)]
+#[doc(hidden)]
 pub enum DetectArgsParseError {
     InvalidArguments,
 }
 
+#[doc(hidden)]
 pub struct BuildArgs {
     pub layers_dir_path: PathBuf,
     pub platform_dir_path: PathBuf,
@@ -221,6 +232,7 @@ impl BuildArgs {
 }
 
 #[derive(Debug)]
+#[doc(hidden)]
 pub enum BuildArgsParseError {
     InvalidArguments,
 }

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -96,7 +96,7 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
     }
 }
 
-fn libcnb_runtime_detect<B: Buildpack>(
+pub fn libcnb_runtime_detect<B: Buildpack>(
     buildpack: &B,
     args: DetectArgs,
 ) -> crate::Result<i32, B::Error> {
@@ -132,7 +132,7 @@ fn libcnb_runtime_detect<B: Buildpack>(
     }
 }
 
-fn libcnb_runtime_build<B: Buildpack>(
+pub fn libcnb_runtime_build<B: Buildpack>(
     buildpack: &B,
     args: BuildArgs,
 ) -> crate::Result<i32, B::Error> {
@@ -177,13 +177,13 @@ fn libcnb_runtime_build<B: Buildpack>(
     }
 }
 
-struct DetectArgs {
+pub struct DetectArgs {
     pub platform_dir_path: PathBuf,
     pub build_plan_path: PathBuf,
 }
 
 impl DetectArgs {
-    fn parse(args: &[String]) -> Result<DetectArgs, DetectArgsParseError> {
+    pub fn parse(args: &[String]) -> Result<DetectArgs, DetectArgsParseError> {
         if let [_, platform_dir_path, build_plan_path] = args {
             Ok(DetectArgs {
                 platform_dir_path: PathBuf::from(platform_dir_path),
@@ -196,18 +196,18 @@ impl DetectArgs {
 }
 
 #[derive(Debug)]
-enum DetectArgsParseError {
+pub enum DetectArgsParseError {
     InvalidArguments,
 }
 
-struct BuildArgs {
+pub struct BuildArgs {
     pub layers_dir_path: PathBuf,
     pub platform_dir_path: PathBuf,
     pub buildpack_plan_path: PathBuf,
 }
 
 impl BuildArgs {
-    fn parse(args: &[String]) -> Result<BuildArgs, BuildArgsParseError> {
+    pub fn parse(args: &[String]) -> Result<BuildArgs, BuildArgsParseError> {
         if let [_, layers_dir_path, platform_dir_path, buildpack_plan_path] = args {
             Ok(BuildArgs {
                 layers_dir_path: PathBuf::from(layers_dir_path),
@@ -221,7 +221,7 @@ impl BuildArgs {
 }
 
 #[derive(Debug)]
-enum BuildArgsParseError {
+pub enum BuildArgsParseError {
     InvalidArguments,
 }
 


### PR DESCRIPTION
Note: Original PR was #370 which didn't apply cleanly after I made changes to @nokome's code in #369. I cherry picked @nokome's commit for proper credit, added docs and updated to changelog.

Note: This commit has been extracted out from https://github.com/Malax/libcnb.rs/pull/313 (which will be superseded by this and other PRs).