### PR TITLE
Only create layer `env` directories if env vars are being written

### DIFF
--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow compilation of libcnb.rs buildpacks on Windows. Please note that this does not imply Windows container support, it's meant to allow running unit tests without cross-compiling. ([#368](https://github.com/Malax/libcnb.rs/pull/368))
 - Expose `runtime::libcnb_runtime_detect`, `runtime::libcnb_runtime_build` and their related types for advanced use-cases. Buildpack authors should not use these. ([#375](https://github.com/Malax/libcnb.rs/pull/375)).
+- Only create layer `env`, `env.build` and `env.launch` directories when environment variables are being set within them ([#385](https://github.com/Malax/libcnb.rs/pull/385)).
 
 ## [0.6.0] 2022-02-28
 


### PR DESCRIPTION
Prevents empty `env`, `env.build` and `env.launch` directories from being created within each layer's directory, if no environment variables are set within them.

Fixes #384.
GUS-W-10905886.