### PR TITLE
Add explicit error for missing exec.d paths

### DIFF
--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Allow compilation of libcnb.rs buildpacks on Windows. Please note that this does not imply Windows container support, it's meant to allow running unit tests without cross-compiling. ([#368](https://github.com/Malax/libcnb.rs/pull/368))
 - Expose `runtime::libcnb_runtime_detect`, `runtime::libcnb_runtime_build` and their related types for advanced use-cases. Buildpack authors should not use these. ([#375](https://github.com/Malax/libcnb.rs/pull/375)).
 - Only create layer `env`, `env.build` and `env.launch` directories when environment variables are being set within them ([#385](https://github.com/Malax/libcnb.rs/pull/385)).
+- Add `WriteLayerError::MissingExecDFile` error to ease debugging when an exec.d path is missing ([#387](https://github.com/Malax/libcnb.rs/pull/387)).
 
 ## [0.6.0] 2022-02-28
 


### PR DESCRIPTION
I recently messed up packaging my buildpack and all exec.d binaries were not properly packaged. The error messages made it hard to understand what was wrong since the error only complains about "file not found" but doesn't tell you anything about which file.

This PR adds an explicit error for missing exec.d paths so this error-case is much easier to debug. This is technically a breaking change for users that manually match `libcnb::Error`. Most users won't be affected if they rely on libcnb handling internal errors.

Closes GUS-W-10919490